### PR TITLE
検索ページの修正

### DIFF
--- a/frontend/components/SpotListDialog.jsx
+++ b/frontend/components/SpotListDialog.jsx
@@ -67,13 +67,14 @@ export const SpotListDialog = ({ editing, selected, open, spots, setEditing, set
   }
 
   const handleComplete = () => {
-    if (selected === -3) {
-      setStartSpot(editing)
-    }
-    else if (selected === -2) {
-      setGoalSpot(editing)
-    }
-    else if (selected === -1) {
+    // if (selected === -3) {
+    //   setStartSpot(editing)
+    // }
+    // else if (selected === -2) {
+    //   setGoalSpot(editing)
+    // }
+    // else if (selected === -1) {
+    if (selected === -1) {
       setSpots(append(editing))
     }
     else {
@@ -88,6 +89,13 @@ export const SpotListDialog = ({ editing, selected, open, spots, setEditing, set
       assoc('name', spot.name)
     )(editing)
     setEditing(newSpot)
+    if (selected === -1) {
+      setSpots(append(newSpot))
+    }
+    else {
+      setSpots(update(selected, newSpot, spots))
+    }
+    setOpen(false)
   }
 
   const spotList = data
@@ -134,7 +142,7 @@ export const SpotListDialog = ({ editing, selected, open, spots, setEditing, set
       </SpotDialogContent>
       <DialogActions>
         <Button onClick={handleClose} color="primary">キャンセル</Button>
-        <Button onClick={handleComplete} color="primary">{selected === -1 ? '追加' : '更新'}</Button>
+        {/* <Button onClick={handleComplete} color="primary">{selected === -1 ? '追加' : '更新'}</Button> */}
       </DialogActions>
     </SpotDialog>
   )

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -31,7 +31,7 @@ const ConditionDatePicker = styled(DatePicker)`
 `
 
 const ConditionTimePicker = styled(TimePicker)`
-  flex-basis: 20%;
+  flex-basis: 30%;
 `
 
 const ConditionTimeModeSelect = styled(TextField)`
@@ -55,16 +55,16 @@ const initialEditing = {
   stayTime: 0
 }
 
-const initialSpot = {
-  spotId: 102,
-  name: 'パークエントランス・ノース・チケットブース'
-}
+// const initialSpot = {
+//   spotId: 102,
+//   name: 'パークエントランス・ノース・チケットブース'
+// }
 
 const Home = () => {
   const [open, setOpen] = useState(false)
   const [editing, setEditing] = useState({})
-  const [startSpot, setStartSpot] = useState(initialSpot)
-  const [goalSpot, setGoalSpot] = useState(initialSpot)
+  // const [startSpot, setStartSpot] = useState(initialSpot)
+  // const [goalSpot, setGoalSpot] = useState(initialSpot)
   const [spots, setSpots] = useState([])
   const [selected, setSelected] = useState(-1)
   const [date, setDate] = useState(new Date())
@@ -96,13 +96,13 @@ const Home = () => {
   return (
     <Wrap>
       <Text>回りたいスポットを入れてね</Text>
-      <SpotButton
+      {/* <SpotButton
         variant="outlined"
         color="primary"
         onClick={handleOpen(startSpot, -3)}
       >
         {startSpot.name}
-      </SpotButton>
+      </SpotButton> */}
       {spots.map((spot, index) =>
         <SpotButton
           key={index}
@@ -120,13 +120,13 @@ const Home = () => {
       >
         追加
       </PlusButton>
-      <SpotButton
+      {/* <SpotButton
         variant="outlined"
         color="primary"
         onClick={handleOpen(goalSpot, -2)}
       >
         {goalSpot.name}
-      </SpotButton>
+      </SpotButton> */}
       <SpotListDialog
         editing={editing}
         selected={selected}
@@ -136,11 +136,11 @@ const Home = () => {
         setOpen={setOpen}
         setSpots={setSpots}
         setIndex={setSelected}
-        setStartSpot={setStartSpot}
-        setGoalSpot={setGoalSpot}
+        // setStartSpot={setStartSpot}
+        // setGoalSpot={setGoalSpot}
       />
       <Condition>
-        <ConditionDatePicker
+        {/* <ConditionDatePicker
           margin="normal"
           label="日付"
           format="MM/dd"
@@ -148,7 +148,7 @@ const Home = () => {
           onChange={handleDate}
           okLabel="決定"
           cancelLabel="キャンセル"
-        />
+        /> */}
         <ConditionTimePicker
           margin="normal"
           label="時間"


### PR DESCRIPTION
* 次の入力インターフェースを削除した
  * スタートスポット
  * ゴールスポット
  * 日付
* スポット選択ダイアログで、「スポット選択→追加(更新)ボタンクリック」と2アクション必要だったのを、「スポット選択」だけにした