### PR TITLE
入力Jsonの形式を修正&到着希望時刻考慮を実装

### DIFF
--- a/backend/disneyapp/data_manager.py
+++ b/backend/disneyapp/data_manager.py
@@ -101,11 +101,26 @@ class StaticDataManager:
 
     @classmethod
     def is_exist_spot_id(cls, target_id):
+        """
+        存在するスポットIDかどうか判定する。存在する場合はTrueを返す。
+        """
         spots = cls.get_spots()
         for spot in spots:
             if target_id == spot["spot_id"]:
                 return True
         return False
+
+    @classmethod
+    def get_spot_attr(cls, target_id):
+        """
+        スポットIDを指定して、そのスポットの情報をdict出返す。
+        存在しないスポットを指定された場合はNoneを返す。
+        """
+        spots = cls.get_spots()
+        for spot in spots:
+            if target_id == spot["spot_id"]:
+                return spot
+        return None
 
 
 class CombinedDatamanager:

--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -9,6 +9,8 @@ class Subroute:
         self.goal_time = ""
         self.distance = -1
         self.transit_time = -1
+        # 目的地の到着希望時刻を破っている場合True
+        self.violate_goal_desired_arrival_time = False
         self.coords = []
 
     def to_dict(self):
@@ -183,13 +185,13 @@ class TravelInput:
         if not StaticDataManager.is_exist_spot_id(travel_input_spot.spot_id):
             self.error_message = "spot-idに存在しないスポットID(" + str(travel_input_spot.spot_id) + ")が指定されています。"
             return None
-        # todo: 開始時刻が指定されているスポットの場合、desired-arrival-timeにその値を詰める
+        # todo: showの場合、desired-arrival-timeにその値を詰める
 
         spot_type = StaticDataManager.get_spot_attr(travel_input_spot.spot_id)["type"]
 
         # desired-arrival-time
         if spot_json.get("desired-arrival-time"):
-            # todo: 開始時刻が指定されているスポットの場合エラーにする
+            # todo: showの場合エラーにする
             if spot_type not in ["attraction", "greeting", "restaurant", "place"]:
                 self.error_message = "desired-arrival-timeを指定できるのは、attraction/greeting/restaurant/placeのいずれかのみです。"
                 return None

--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -195,7 +195,7 @@ class TravelInput:
             try:
                 # hh:mm -> 秒数 への変換
                 hh_str, mm_str = spot_json["desired-arrival-time"].split(":")
-                self.specified_time = int(hh_str) * 3600 + int(mm_str) * 60
+                travel_input_spot.desired_arrival_time = int(hh_str) * 3600 + int(mm_str) * 60
             except:
                 self.error_message = "時間の形式が不正です。hh:mm形式で指定してください。"
                 return None

--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -1,5 +1,6 @@
 from disneyapp.data_manager import StaticDataManager
 
+
 class Subroute:
     def __init__(self):
         self.start_spot_id = -1
@@ -70,7 +71,9 @@ class Tour:
 class TravelInputSpot:
     def __init__(self):
         self.spot_id = -1
+        self.desired_arrival_time = 0  # 00:00 からの経過秒数
         self.stay_time = -1  # [秒]
+        self.specified_wait_time = 0  # [秒]
 
 
 class TravelInput:
@@ -78,25 +81,33 @@ class TravelInput:
         self.time_mode = ""
         self.specified_time = 0  # 00:00からの経過秒数
         self.walk_speed = ""
+        self.start_spot_id = -1
+        self.goal_spot_id = -1
         self.spots = []
         self.error_message = ""
         self.init_by_json(json_data)
 
-    def init_by_json(self, json_data):
-        # time_mode
+    def __init_time_mode(self, json_data):
+        """
+        time_modeを初期化する。初期化に失敗した場合はFalseを返す。
+        """
         if not json_data.get("time-mode"):
             self.error_message = "time-modeが存在しません。"
-            return
+            return False
         self.time_mode = json_data["time-mode"]
         valid_time_mode_list = ["start", "end"]
         if self.time_mode not in valid_time_mode_list:
             self.error_message = "time-modeはstart/endのいずれかを指定してください。"
-            return
+            return False
+        return True
 
-        # specified-time
+    def __init_specified_time(self, json_data):
+        """
+        specified_timeを初期化する。初期化に失敗した場合はFalseを返す。
+        """
         if not json_data.get("specified-time"):
             self.error_message = "specified-timeが存在しません。"
-            return
+            return False
         specified_time_str = json_data["specified-time"]
         try:
             # hh:mm -> 秒数 への変換
@@ -104,43 +115,141 @@ class TravelInput:
             self.specified_time = int(hh_str) * 3600 + int(mm_str) * 60
         except:
             self.error_message = "時間の形式が不正です。hh:mm形式で指定してください。"
+            return False
+        return True
 
-        # walk-speed
+    def __init_walk_speed(self, json_data):
+        """
+        walk_speedを初期化する。初期化に失敗した場合はFalseを返す。
+        """
         if not json_data.get("walk-speed"):
             self.error_message = "walk-speedが存在しません。"
-            return
+            return False
         self.walk_speed = json_data["walk-speed"]
         valid_walk_speed_list = ["slow", "normal", "fast"]
         if self.walk_speed not in valid_walk_speed_list:
             self.error_message = "walk-speedはslow/normal/fastのいずれかを指定してください。"
-            return
+            return False
+        return True
 
-        # spots
+    def __init_start_spot_id(self, json_data):
+        """
+        start_spot_idを初期化する。初期化に失敗した場合はFalseを返す。
+        """
+        if not json_data.get("start-spot-id"):
+            self.error_message = "start-spot-idが存在しません。"
+            return False
+        try:
+            self.start_spot_id = int(json_data["start-spot-id"])
+        except:
+            self.error_message = "start-spot-idには整数を指定してください。"
+            return False
+        if not StaticDataManager.is_exist_spot_id(self.start_spot_id):
+            self.error_message = "start-spot-idに存在しないスポットID(" + str(self.start_spot_id) + ")が指定されています。"
+            return False
+        return True
+
+    def __init_goal_spot_id(self, json_data):
+        """
+        goal_spot_idを初期化する。初期化に失敗した場合はFalseを返す。
+        """
+        if not json_data.get("goal-spot-id"):
+            self.error_message = "goal-spot-idが存在しません。"
+            return False
+        try:
+            self.goal_spot_id = int(json_data["goal-spot-id"])
+        except:
+            self.error_message = "goal-spot-idには整数を指定してください。"
+            return False
+        if not StaticDataManager.is_exist_spot_id(self.goal_spot_id):
+            self.error_message = "goal-spot-idに存在しないスポットID(" + str(self.goal_spot_id) + ")が指定されています。"
+            return False
+        return True
+
+    def __init_spot(self, spot_json):
+        """
+        TravelInputSpotオブジェクトを生成する。
+        生成に失敗した場合はNoneを返す。
+        """
+        # spot-id
+        if not spot_json.get("spot-id"):
+            self.error_message = "spot-idの存在しないspotが存在します。"
+            return None
+        travel_input_spot = TravelInputSpot()
+        try:
+            travel_input_spot.spot_id = int(spot_json["spot-id"])
+        except:
+            self.error_message = "spot-idには整数を指定してください。"
+            return None
+        if not StaticDataManager.is_exist_spot_id(travel_input_spot.spot_id):
+            self.error_message = "spot-idに存在しないスポットID(" + str(travel_input_spot.spot_id) + ")が指定されています。"
+            return None
+
+        spot_type = StaticDataManager.get_spot_attr(travel_input_spot.spot_id)["type"]
+
+        # desired-arrival-time
+        if spot_json.get("desired-arrival-time"):
+            if spot_type not in ["attraction", "greeting", "restaurant", "place"]:
+                self.error_message = "desired-arrival-timeを指定できるのは、attraction/greeting/restaurant/placeのいずれかのみです。"
+                return None
+            try:
+                # hh:mm -> 秒数 への変換
+                hh_str, mm_str = spot_json["desired-arrival-time"].split(":")
+                self.specified_time = int(hh_str) * 3600 + int(mm_str) * 60
+            except:
+                self.error_message = "時間の形式が不正です。hh:mm形式で指定してください。"
+                return None
+
+        # stay-time
+        if spot_json.get("stay-time"):
+            if spot_type not in ["restaurant", "shop"]:
+                self.error_message = "stay-timeを指定できるのは、restaurant/shopのいずれかのみです。"
+                return None
+            try:
+                travel_input_spot.stay_time = int(spot_json["stay-time"]) * 60
+            except:
+                self.error_message = "stay-timeには整数を指定してください。"
+                return None
+
+        # specified-wait-time
+        if spot_json.get("specified-wait-time"):
+            if spot_type != "show":
+                self.error_message = "specified-wait-timeを指定できるのはshowのみです。"
+                return None
+            try:
+                travel_input_spot.specified_wait_time = int(spot_json["specified-wait-time"]) * 60
+            except:
+                self.error_message = "specified-wait-timeには整数を指定してください。"
+                return None
+
+        return travel_input_spot
+
+    def __init_spots(self, json_data):
+        """
+        spotsを初期化する。初期化に失敗した場合はFalseを返す。
+        """
         if not json_data.get("spots"):
             self.error_message = "spotsが存在しません。"
-            return
+            return False
         spots = json_data["spots"]
         if len(spots) < 3:
             self.error_message = "spotsの要素数は3つ以上指定してください。"
-            return
-        for spot in spots:
-            if not spot.get("spot-id"):
-                self.error_message = "spot-idの存在しないspotが存在します。"
-                return
-            travel_input_spot = TravelInputSpot()
-            try:
-                travel_input_spot.spot_id = int(spot["spot-id"])
-            except:
-                self.error_message = "spot-idには整数を指定してください。"
-                return
-            if not StaticDataManager.is_exist_spot_id(travel_input_spot.spot_id):
-                self.error_message = "spot-idに存在しないスポットID(" + str(travel_input_spot.spot_id) + ")が指定されています。"
-                return
-            if json_data.get("stay-time"):
-                try:
-                    travel_input_spot.stay_time = int(json_data["stay-time"])
-                except:
-                    self.error_message = "stay-timeには整数を指定してください。"
+            return False
+        for spot_json in spots:
+            if not (travel_input_spot := self.__init_spot(spot_json)):
+                return False
             self.spots.append(travel_input_spot)
+        return True
 
-
+    def init_by_json(self, json_data):
+        if not self.__init_time_mode(json_data):
+            return
+        if not self.__init_specified_time(json_data):
+            return
+        if not self.__init_walk_speed(json_data):
+            return
+        if not self.__init_start_spot_id(json_data):
+            return
+        if not self.__init_goal_spot_id(json_data):
+            return
+        self.__init_spots(json_data)


### PR DESCRIPTION
### 概要
* 入力Jsonの形式の修正に合わせて、エラーハンドリングを追加
  * 修正後のJsonの仕様を下記のページにまとめているため参照のこと
    * https://github.com/Nakajima2nd/disney-app/wiki/search-%E3%81%AE%E4%BB%95%E6%A7%98
* 到着希望時刻(`desired-arrival-time`)の考慮処理を実装

### Jsonパラメタの主な修正点
* 必須パラメタに下記を追加
  * `start-spot-id`
  * `goal-spot-id`
* スポットごとの任意パラメタに下記を追加
  * specified-wait-time : int(分)
    * ショーの待ち時間（いわゆる場所取りの時間）を指定する

### 検証
* `https://disney-app-api.herokuapp.com/search にデプロイして検証を実施し、Wikiの仕様通りのエラーハンドリングができていることを一通り確認
* スポットの到着希望時刻をいくつか変化させて探索を実施し、到着希望時刻を守る経路が出ることを確認
  * 例：下記の入力で `/search` をたたくと、spot_id=0(ソアリン)に10:30に到着する経路が出ることを確認。
    * ソアリンの到着希望時刻を11:00などに変化させると、それに合わせて巡回経路も変化する
```
{
    "time-mode": "start",
    "specified-time": "10:00",
    "walk-speed": "slow",
	"start-spot-id" : "103",
	"goal-spot-id" : "103",
    "spots": [
        {
            "spot-id": "5"
        },
        {
            "spot-id": "0",
            "desired-arrival-time": "10:30"
        },
        {
            "spot-id": "17"
        },
        {
            "spot-id": "27"
        }
    ]
}
```