### PR TITLE
spotに短縮名称とURLを追加

### DIFF
--- a/backend/data/sea/spots.json
+++ b/backend/data/sea/spots.json
@@ -3,417 +3,514 @@
         {
             "spot_id": 0,
             "name": "ソアリン：ファンタスティック・フライト",
+            "short-name": "ソアリン",
             "lat": "35.62753096260775",
             "lon": "139.88570175371126",
             "type": "attraction",
             "nearest_node_id": 8,
-            "play-time": "300"
+            "play-time": "300",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/219/"
         },
         {
             "spot_id": 1,
             "name": "ディズニーシー・トランジットスチーマーライン（メディテレーニアンハーバー）",
+            "short-name": "トランジットスチーマーライン(ハーバー)",
             "lat": "35.626573169189264",
             "lon": "139.88593456101927",
             "type": "attraction",
             "nearest_node_id": 10,
-            "play-time": "420"
+            "play-time": "420",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/227/"
         },
         {
             "spot_id": 2,
             "name": "フォートレス・エクスプロレーション",
+            "short-name": "フォートレス・エクスプロレーション",
             "lat": "35.62577595814663",
             "lon": "139.88521622867762",
             "type": "attraction",
-            "nearest_node_id": 45
+            "nearest_node_id": 45,
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/244/"
         },
         {
             "spot_id": 3,
             "name": "ヴェネツィアン・ゴンドラ",
+            "short-name": "ヴェネツィアン・ゴンドラ",
             "lat": "35.62609086477499",
             "lon": "139.88796327515433",
             "type": "attraction",
             "nearest_node_id": 21,
-            "play-time": "690"
+            "play-time": "690",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/230/"
         },
         {
             "spot_id": 4,
             "name": "タートル・トーク",
+            "short-name": "タートル・トーク",
             "lat": "35.62334375031604",
             "lon": "139.88726518210083",
             "type": "attraction",
             "nearest_node_id": 100,
-            "play-time": "1800"
+            "play-time": "1800",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/246/"
         },
         {
             "spot_id": 5,
             "name": "タワー・オブ・テラー",
+            "short-name": "タワー・オブ・テラー",
             "lat": "35.62391248028388",
             "lon": "139.88828835075003",
             "type": "attraction",
             "nearest_node_id": 36,
-            "play-time": "120"
+            "play-time": "120",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/243/"
         },
         {
             "spot_id": 6,
             "name": "ディズニーシー・エレクトリックレールウェイ（アメリカンウォーターフロント）",
+            "short-name": "エレクトリックレールウェイ(アメフロ)",
             "lat": "35.62491145456335",
             "lon": "139.88775091735545",
             "type": "attraction",
             "nearest_node_id": 25,
-            "play-time": "150"
+            "play-time": "150",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/232/"
         },
         {
             "spot_id": 7,
             "name": "ディズニーシー・トランジットスチーマーライン（アメリカンウォーターフロント）",
+            "short-name": "トランジットスチーマーライン(アメフロ)",
             "lat": "35.62420292517226",
             "lon": "139.88569672120138",
             "type": "attraction",
             "nearest_node_id": 51,
-            "play-time": "780"
+            "play-time": "780",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/228/"
         },
         {
             "spot_id": 8,
             "name": "トイ・ストーリー・マニア！",
+            "short-name": "トイ・ストーリー・マニア！",
             "lat": "35.62477700583167",
             "lon": "139.8889301319155",
             "type": "attraction",
             "nearest_node_id": 28,
-            "play-time": "420"
+            "play-time": "420",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/218/"
         },
         {
             "spot_id": 9,
             "name": "ビッグシティ・ヴィークル",
+            "short-name": "ビッグシティ・ヴィークル",
             "lat": "35.62439387470845",
             "lon": "139.88706200880483",
             "type": "attraction",
             "nearest_node_id": 37,
-            "play-time": "600"
+            "play-time": "600",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/233/"
         },
         {
             "spot_id": 10,
             "name": "アクアトピア",
+            "short-name": "アクアトピア",
             "lat": "35.62468589551906",
             "lon": "139.88349606906613",
             "type": "attraction",
             "nearest_node_id": 60,
-            "play-time": "150"
+            "play-time": "150",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/234/"
         },
         {
             "spot_id": 11,
             "name": "ディズニーシー・エレクトリックレールウェイ（ポートディスカバリー）",
+            "short-name": "エレクトリックレールウェイ(ポートディスカバリー)",
             "lat": "35.62539074665123",
             "lon": "139.88309169515944",
             "type": "attraction",
             "nearest_node_id": 62,
-            "play-time": "150"
+            "play-time": "150",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/231/"
         },
         {
             "spot_id": 12,
             "name": "ニモ＆フレンズ・シーライダー",
+            "short-name": "ニモ＆フレンズ・シーライダー",
             "lat": "35.62494825695022",
             "lon": "139.88251554646882",
             "type": "attraction",
             "nearest_node_id": 64,
-            "play-time": "300"
+            "play-time": "300",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/247/"
         },
         {
             "spot_id": 13,
             "name": "インディ・ジョーンズ・アドベンチャー： クリスタルスカルの魔宮",
+            "short-name": "インディ・ジョーンズ",
             "lat": "35.6263737631128",
             "lon": "139.8809767843943",
             "type": "attraction",
             "nearest_node_id": 75,
-            "play-time": "180"
+            "play-time": "180",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/222/"
         },
         {
             "spot_id": 14,
             "name": "ディズニーシー・トランジットスチーマーライン（ロストリバーデルタ）",
+            "short-name": "ランジットスチーマーライン(ロストリバーデルタ)",
             "lat": "35.62673965820737",
             "lon": "139.8819008279609",
             "type": "attraction",
             "nearest_node_id": 86,
-            "play-time": "360"
+            "play-time": "360",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/229/"
         },
         {
             "spot_id": 15,
             "name": "レイジングスピリッツ",
+            "short-name": "レイジングスピリッツ",
             "lat": "35.627722226399435",
             "lon": "139.88080457814263",
             "type": "attraction",
             "nearest_node_id": 78,
-            "play-time": "90"
+            "play-time": "90",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/242/"
         },
         {
             "spot_id": 16,
             "name": "キャラバンカルーセル",
+            "short-name": "キャラバンカルーセル",
             "lat": "35.62817027479872",
             "lon": "139.88333969788812",
             "type": "attraction",
             "nearest_node_id": 70,
-            "play-time": "150"
+            "play-time": "150",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/236/"
         },
         {
             "spot_id": 17,
             "name": "ジャスミンのフライングカーペット",
+            "short-name": "フライングカーペット",
             "lat": "35.62835033507712",
             "lon": "139.88110064513887",
             "type": "attraction",
             "nearest_node_id": 89,
-            "play-time": "90"
+            "play-time": "90",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/220/"
         },
         {
             "spot_id": 18,
             "name": "シンドバッド・ストーリーブック・ヴォヤッジ",
+            "short-name": "シンドバッド・ストーリーブック・ヴォヤッジ",
             "lat": "35.628507999414445",
             "lon": "139.8814498574758",
             "type": "attraction",
             "nearest_node_id": 88,
-            "play-time": "600"
+            "play-time": "600",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/235/"
         },
         {
             "spot_id": 19,
             "name": "マジックランプシアター",
+            "short-name": "マジックランプシアター",
             "lat": "35.628433782867795",
             "lon": "139.88306798035555",
             "type": "attraction",
             "nearest_node_id": 71,
-            "play-time": "1380"
+            "play-time": "1380",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/226/"
         },
         {
             "spot_id": 20,
             "name": "アリエルのプレイグラウンド",
+            "short-name": "アリエルのプレイグラウンド",
             "lat": "35.62679154348968",
             "lon": "139.8833172765092",
             "type": "attraction",
-            "nearest_node_id": 91
+            "nearest_node_id": 91,
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/202/"
         },
         {
             "spot_id": 21,
             "name": "ジャンピン・ジェリーフィッシュ",
+            "short-name": "ジャンピン・ジェリーフィッシュ",
             "lat": "35.626514238390236",
             "lon": "139.88340256425997",
             "type": "attraction",
             "nearest_node_id": 94,
-            "play-time": "60"
+            "play-time": "60",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/239/"
         },
         {
             "spot_id": 22,
             "name": "スカットルのスクーター",
+            "short-name": "スカットルのスクーター",
             "lat": "35.62726987355347",
             "lon": "139.88321567037846",
             "type": "attraction",
             "nearest_node_id": 97,
-            "play-time": "90"
+            "play-time": "90",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/238/"
         },
         {
             "spot_id": 23,
             "name": "フランダーのフライングフィッシュコースター",
+            "short-name": "フライングフィッシュコースター",
             "lat": "35.627035483426376",
             "lon": "139.88224597144833",
             "type": "attraction",
             "nearest_node_id": 82,
-            "play-time": "60"
+            "play-time": "60",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/237/"
         },
         {
             "spot_id": 24,
             "name": "ブローフィッシュ・バルーンレース",
+            "short-name": "ブローフィッシュ・バルーンレース",
             "lat": "35.626468454526325",
             "lon": "139.88290367341438",
             "type": "attraction",
             "nearest_node_id": 96,
-            "play-time": "90"
+            "play-time": "90",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/240/"
         },
         {
             "spot_id": 25,
             "name": "マーメイドラグーンシアター",
+            "short-name": "マーメイドラグーンシアター",
             "lat": "35.62640700722643",
             "lon": "139.88271825269382",
             "type": "attraction",
             "nearest_node_id": 140,
-            "play-time": "840"
+            "play-time": "840",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/221/"
         },
         {
             "spot_id": 26,
             "name": "ワールプール",
+            "short-name": "ワールプール",
             "lat": "35.626673391618006",
             "lon": "139.88312897895753",
             "type": "attraction",
             "nearest_node_id": 93,
-            "play-time": "90"
+            "play-time": "90",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/241/"
         },
         {
             "spot_id": 27,
             "name": "海底2万マイル",
+            "short-name": "海底2万マイル",
             "lat": "35.62641929875694",
             "lon": "139.88461075873784",
             "type": "attraction",
             "nearest_node_id": 14,
-            "play-time": "300"
+            "play-time": "300",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/224/"
         },
         {
             "spot_id": 28,
             "name": "センター・オブ・ジ・アース",
+            "short-name": "センター・オブ・ジ・アース",
             "lat": "35.62591270174353",
             "lon": "139.88453268519172",
             "type": "attraction",
             "nearest_node_id": 99,
-            "play-time": "180"
+            "play-time": "180",
+            "url": "https://www.tokyodisneyresort.jp/tds/attraction/detail/223/"
         },
         {
             "spot_id": 29,
             "name": "カフェ・ポルトフィーノ",
+            "short-name": "カフェ・ポルトフィーノ",
             "lat": "35.62695264833476",
             "lon": "139.88714679981504",
             "type": "restaurant",
-            "nearest_node_id": 118
+            "nearest_node_id": 118,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/400/"
         },
         {
             "spot_id": 30,
             "name": "ゴンドリエ・スナック",
+            "short-name": "ゴンドリエ・スナック",
             "lat": "35.625966268892086",
             "lon": "139.88730258806373",
             "type": "restaurant",
-            "nearest_node_id": 31
+            "nearest_node_id": 31,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/411/"
         },
         {
             "spot_id": 31,
             "name": "ザンビーニ･ブラザーズ･リストランテ",
+            "short-name": "ザンビーニ･ブラザーズ･リストランテ",
             "lat": "35.627169846655995",
             "lon": "139.8860085445333",
             "type": "restaurant",
-            "nearest_node_id": 11
+            "nearest_node_id": 11,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/403/"
         },
         {
             "spot_id": 32,
             "name": "マゼランズ",
+            "short-name": "マゼランズ",
             "lat": "35.62593079188322",
             "lon": "139.88528718994823",
             "type": "restaurant",
-            "nearest_node_id": 122
+            "nearest_node_id": 122,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/412/"
         },
         {
             "spot_id": 33,
             "name": "マゼランズ・ラウンジ",
+            "short-name": "マゼランズ・ラウンジ",
             "lat": "35.62591171513723",
             "lon": "139.88533479915824",
             "type": "restaurant",
-            "nearest_node_id": 122
+            "nearest_node_id": 122,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/415/"
         },
         {
             "spot_id": 34,
             "name": "マンマ・ビスコッティーズ・ベーカリー",
+            "short-name": "マンマ・ビスコッティーズ",
             "lat": "35.627031123601206",
             "lon": "139.88761556530423",
             "type": "restaurant",
-            "nearest_node_id": 114
+            "nearest_node_id": 114,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/401/"
         },
         {
             "spot_id": 35,
             "name": "リストランテ・ディ・カナレット",
+            "short-name": "カナレット",
             "lat": "35.6256768376592",
             "lon": "139.8878840659662",
             "type": "restaurant",
-            "nearest_node_id": 22
+            "nearest_node_id": 22,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/401/"
         },
         {
             "spot_id": 36,
             "name": "リフレスコス",
+            "short-name": "リフレスコス",
             "lat": "35.625922848537776",
             "lon": "139.88498528406274",
             "type": "restaurant",
-            "nearest_node_id": 120
+            "nearest_node_id": 120,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/416/"
         },
         {
             "spot_id": 37,
             "name": "S.S.コロンビア・ダイニングルーム",
+            "short-name": "S.S.コロンビア・ダイニングルーム",
             "lat": "35.62336259993873",
             "lon": "139.88722275593676",
             "type": "restaurant",
-            "nearest_node_id": 100
+            "nearest_node_id": 100,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/menu/425/"
         },
         {
             "spot_id": 38,
             "name": "ケープコッド・クックオフ",
+            "short-name": "ケープコッド・クックオフ",
             "lat": "35.62454246535265",
             "lon": "139.88510562868893",
             "type": "restaurant",
-            "nearest_node_id": 127
+            "nearest_node_id": 127,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/446/"
         },
         {
             "spot_id": 39,
             "name": "ケープコッド・コンフェクション",
+            "short-name": "ケープコッド・コンフェクション",
             "lat": "35.62455907346721",
             "lon": "139.8849652703674",
             "type": "restaurant",
-            "nearest_node_id": 125
+            "nearest_node_id": 125,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/448/"
         },
         {
             "spot_id": 40,
             "name": "ドックサイドダイナー",
+            "short-name": "ドックサイドダイナー",
             "lat": "35.62377706755055",
             "lon": "139.88760165630976",
             "type": "restaurant",
-            "nearest_node_id": 38
+            "nearest_node_id": 38,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/441/"
         },
         {
             "spot_id": 41,
             "name": "テディ・ルーズヴェルト・ラウンジ",
+            "short-name": "テディ・ルーズヴェルト・ラウンジ",
             "lat": "35.62340244500671",
             "lon": "139.887249490907",
             "type": "restaurant",
-            "nearest_node_id": 100
+            "nearest_node_id": 100,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/429/"
         },
         {
             "spot_id": 42,
             "name": "デランシー・ケータリング",
+            "short-name": "デランシー・ケータリング",
             "lat": "35.62486059009338",
             "lon": "139.8875073792503",
             "type": "restaurant",
-            "nearest_node_id": 33
+            "nearest_node_id": 33,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/423/"
         },
         {
             "spot_id": 43,
             "name": "ニューヨーク・デリ",
+            "short-name": "ニューヨーク・デリ",
             "lat": "35.625360255196206",
             "lon": "139.8878674000761",
             "type": "restaurant",
-            "nearest_node_id": 24
+            "nearest_node_id": 24,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/422/"
         },
         {
             "spot_id": 44,
             "name": "バーナクル・ビルズ",
+            "short-name": "バーナクル・ビルズ",
             "lat": "35.624057270334205",
             "lon": "139.88680246759344",
             "type": "restaurant",
-            "nearest_node_id": 41
+            "nearest_node_id": 41,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/430/"
         },
         {
             "spot_id": 45,
             "name": "ハイタイド・トリート",
+            "short-name": "ハイタイド・トリート",
             "lat": "35.624982684284234",
             "lon": "139.88435859423043",
             "type": "restaurant",
-            "nearest_node_id": 50
+            "nearest_node_id": 50,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/449/"
         },
         {
             "spot_id": 46,
             "name": "ハドソンリバー・ハーベスト",
+            "short-name": "ハドソンリバー・ハーベスト",
             "lat": "35.623791799452526",
             "lon": "139.88736299869663",
             "type": "restaurant",
-            "nearest_node_id": 38
+            "nearest_node_id": 38,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/498/"
         },
         {
             "spot_id": 47,
             "name": "パパダキス・フレッシュフルーツ",
+            "short-name": "パパダキス・フレッシュフルーツ",
             "lat": "35.6241067916498",
             "lon": "139.88698791986826",
             "type": "restaurant",
-            "nearest_node_id": 41
+            "nearest_node_id": 41,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/440/"
         },
         {
             "spot_id": 48,
             "name": "リバティ・ランディング・ダイナー",
+            "short-name": "リバティ・ランディング・ダイナー",
             "lat": "35.62453805491093",
             "lon": "139.88702237925037",
             "type": "restaurant",
@@ -422,446 +519,557 @@
         {
             "spot_id": 49,
             "name": "レストラン櫻",
+            "short-name": "レストラン櫻",
             "lat": "35.624750388158205",
             "lon": "139.88706780260532",
             "type": "restaurant",
-            "nearest_node_id": 33
+            "nearest_node_id": 33,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/435/"
         },
         {
             "spot_id": 50,
             "name": "レストラン櫻 テラス席",
+            "short-name": "レストラン櫻 テラス席",
             "lat": "35.62463665215171",
             "lon": "139.88699008414704",
             "type": "restaurant",
-            "nearest_node_id": 37
+            "nearest_node_id": 37,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/436/"
         },
         {
             "spot_id": 51,
             "name": "シーサイドスナック",
+            "short-name": "シーサイドスナック",
             "lat": "35.624226490084894",
             "lon": "139.88407739704098",
             "type": "restaurant",
-            "nearest_node_id": 56
+            "nearest_node_id": 56,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/450/"
         },
         {
             "spot_id": 52,
             "name": "ブリーズウェイ・バイツ",
+            "short-name": "ブリーズウェイ・バイツ",
             "lat": "35.62557288181555",
             "lon": "139.8832934499238",
             "type": "restaurant",
-            "nearest_node_id": 49
+            "nearest_node_id": 49,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/454/"
         },
         {
             "spot_id": 53,
             "name": "ベイサイド・テイクアウト",
+            "short-name": "ベイサイド・テイクアウト",
             "lat": "35.62534787349407",
             "lon": "139.88303017036733",
             "type": "restaurant",
-            "nearest_node_id": 62
+            "nearest_node_id": 62,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/453/"
         },
         {
             "spot_id": 54,
             "name": "ホライズンベイ・レストラン",
+            "short-name": "ホライズンベイ・レストラン",
             "lat": "35.625329434540184",
             "lon": "139.88332197925132",
             "type": "restaurant",
-            "nearest_node_id": 62
+            "nearest_node_id": 62,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/451/"
         },
         {
             "spot_id": 55,
             "name": "エクスペディション・イート",
+            "short-name": "エクスペディション・イート",
             "lat": "35.62655199342709",
             "lon": "139.88147863907696",
             "type": "restaurant",
-            "nearest_node_id": 76
+            "nearest_node_id": 76,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/460/"
         },
         {
             "spot_id": 56,
             "name": "トロピック・アルズ",
+            "short-name": "トロピック・アルズ",
             "lat": "35.62733398487032",
             "lon": "139.88214863509043",
             "type": "restaurant",
-            "nearest_node_id": 79
+            "nearest_node_id": 79,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/457/"
         },
         {
             "spot_id": 57,
             "name": "ミゲルズ・エルドラド・キャンティーナ",
+            "short-name": "ミゲルズ・エルドラド・キャンティーナ",
             "lat": "35.62635353687072",
             "lon": "139.88221841668994",
             "type": "restaurant",
-            "nearest_node_id": 86
+            "nearest_node_id": 86,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/456/"
         },
         {
             "spot_id": 58,
             "name": "ユカタン・ベースキャンプ・グリル",
+            "short-name": "ユカタン・ベースキャンプ・グリル",
             "lat": "35.62685932680087",
             "lon": "139.8807422907195",
             "type": "restaurant",
-            "nearest_node_id": 137
+            "nearest_node_id": 137,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/459/"
         },
         {
             "spot_id": 59,
             "name": "ロストリバークックハウス",
+            "short-name": "ロストリバークックハウス",
             "lat": "35.627528730257204",
             "lon": "139.88129555984574",
             "type": "restaurant",
-            "nearest_node_id": 78
+            "nearest_node_id": 78,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/461/"
         },
         {
             "spot_id": 60,
             "name": "オープンセサミ",
+            "short-name": "オープンセサミ",
             "lat": "35.628332835176884",
             "lon": "139.8818056970414",
             "type": "restaurant",
-            "nearest_node_id": 68
+            "nearest_node_id": 68,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/465/"
         },
         {
             "spot_id": 61,
             "name": "カスバ・フードコート",
+            "short-name": "カスバ・フードコート",
             "lat": "35.628467652267155",
             "lon": "139.88271758423892",
             "type": "restaurant",
-            "nearest_node_id": 129
+            "nearest_node_id": 129,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/463/"
         },
         {
             "spot_id": 62,
             "name": "サルタンズ・オアシス",
+            "short-name": "サルタンズ・オアシス",
             "lat": "35.62806195659733",
             "lon": "139.88205571876244",
             "type": "restaurant",
-            "nearest_node_id": 68
+            "nearest_node_id": 68,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/464/"
         },
         {
             "spot_id": 63,
             "name": "セバスチャンのカリプソキッチン",
+            "short-name": "カリプソキッチン",
             "lat": "35.626576161868144",
             "lon": "139.88250134014066",
             "type": "restaurant",
-            "nearest_node_id": 0
+            "nearest_node_id": 0,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/468/"
         },
         {
             "spot_id": 64,
             "name": "ヴォルケイニア・レストラン",
+            "short-name": "ヴォルケイニア・レストラン",
             "lat": "35.626687726652065",
             "lon": "139.8843650691074",
             "type": "restaurant",
-            "nearest_node_id": 48
+            "nearest_node_id": 48,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/418/"
         },
         {
             "spot_id": 65,
             "name": "ノーチラスギャレー",
+            "short-name": "ノーチラスギャレー",
             "lat": "35.6262659901122",
             "lon": "139.88424979704135",
             "type": "restaurant",
-            "nearest_node_id": 47
+            "nearest_node_id": 47,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/421/"
         },
         {
             "spot_id": 66,
             "name": "リフレッシュメント・ステーション",
+            "short-name": "リフレッシュメント・ステーション",
             "lat": "35.62654293516153",
             "lon": "139.8838738970412",
             "type": "restaurant",
-            "nearest_node_id": 48
+            "nearest_node_id": 48,
+            "url": "https://www.tokyodisneyresort.jp/tds/restaurant/detail/419/"
         },
         {
             "spot_id": 67,
             "name": "イル・ポスティーノ・ステーショナリー",
+            "short-name": "イル・ポスティーノ・ステーショナリー",
             "lat": "35.627053829792416",
             "lon": "139.8864666793604",
             "type": "shop",
-            "nearest_node_id": 117
+            "nearest_node_id": 117,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/604/"
         },
         {
             "spot_id": 68,
             "name": "ヴァレンティーナズ・スウィート",
+            "short-name": "ヴァレンティーナズ・スウィート",
             "lat": "35.62689230914014",
             "lon": "139.88835381094933",
             "type": "shop",
-            "nearest_node_id": 6
+            "nearest_node_id": 6,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/600/"
         },
         {
             "spot_id": 69,
             "name": "ヴィラ・ドナルド・ホームショップ",
+            "short-name": "ヴィラ・ドナルド・ホームショップ",
             "lat": "35.626212786779085",
             "lon": "139.88740088518182",
             "type": "shop",
-            "nearest_node_id": 30
+            "nearest_node_id": 30,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/616/"
         },
         {
             "spot_id": 70,
             "name": "ヴェネツィアン・カーニバル・マーケット",
+            "short-name": "ヴェネツィアン・カーニバル・マーケット",
             "lat": "35.626337270308056",
             "lon": "139.88757496709434",
             "type": "shop",
-            "nearest_node_id": 30
+            "nearest_node_id": 30,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/615/"
         },
         {
             "spot_id": 71,
             "name": "エンポーリオ",
+            "short-name": "エンポーリオ",
             "lat": "35.62690536565524",
             "lon": "139.88788725437888",
             "type": "shop",
-            "nearest_node_id": 113
+            "nearest_node_id": 113,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/601/"
         },
         {
             "spot_id": 72,
             "name": "ガッレリーア・ディズニー",
+            "short-name": "ガッレリーア・ディズニー",
             "lat": "35.62671446795919",
             "lon": "139.8884136892084",
             "type": "shop",
-            "nearest_node_id": 6
+            "nearest_node_id": 6,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/611/"
         },
         {
             "spot_id": 73,
             "name": "スプレンディード",
+            "short-name": "スプレンディード",
             "lat": "35.62657375882438",
             "lon": "139.88785306090304",
             "type": "shop",
-            "nearest_node_id": 17
+            "nearest_node_id": 17,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/613/"
         },
         {
             "spot_id": 74,
             "name": "ピッコロメルカート",
+            "short-name": "ピッコロメルカート",
             "lat": "35.62685455442086",
             "lon": "139.88760179728777",
             "type": "shop",
-            "nearest_node_id": 112
+            "nearest_node_id": 112,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/602/"
         },
         {
             "spot_id": 75,
             "name": "フィガロズ・クロージアー",
+            "short-name": "フィガロズ・クロージアー",
             "lat": "35.62654965539287",
             "lon": "139.8880709872984",
             "type": "shop",
-            "nearest_node_id": 6
+            "nearest_node_id": 6,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/612/"
         },
         {
             "spot_id": 76,
             "name": "フォトグラフィカ",
+            "short-name": "フォトグラフィカ",
             "lat": "35.62668337182324",
             "lon": "139.8885987434835",
             "type": "shop",
-            "nearest_node_id": 3
+            "nearest_node_id": 3,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/608/"
         },
         {
             "spot_id": 77,
             "name": "ベッラ・ミンニ・コレクション",
+            "short-name": "ベッラ・ミンニ・コレクション",
             "lat": "35.62708041807728",
             "lon": "139.88659347207502",
             "type": "shop",
-            "nearest_node_id": 117
+            "nearest_node_id": 117,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/605/"
         },
         {
             "spot_id": 78,
             "name": "マーチャント・オブ・ヴェニス・コンフェクション",
+            "short-name": "マーチャント・オブ・ヴェニス・コンフェクション",
             "lat": "35.62643965005653",
             "lon": "139.88783629286553",
             "type": "shop",
-            "nearest_node_id": 19
+            "nearest_node_id": 19,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/614/"
         },
         {
             "spot_id": 79,
             "name": "ミラマーレ",
+            "short-name": "ミラマーレ",
             "lat": "35.62697708019846",
             "lon": "139.88680208614412",
             "type": "shop",
-            "nearest_node_id": 118
+            "nearest_node_id": 118,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/606/"
         },
         {
             "spot_id": 80,
             "name": "リメンブランツェ",
+            "short-name": "リメンブランツェ",
             "lat": "35.62518935048507",
             "lon": "139.88613344087182",
             "type": "shop",
-            "nearest_node_id": 55
+            "nearest_node_id": 55,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/617/"
         },
         {
             "spot_id": 81,
             "name": "アーント・ペグズ・ヴィレッジストア",
+            "short-name": "アーント・ペグズ・ヴィレッジストア",
             "lat": "35.62451924491055",
             "lon": "139.88455212560146",
             "type": "shop",
-            "nearest_node_id": 123
+            "nearest_node_id": 123,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/629/"
         },
         {
             "spot_id": 82,
             "name": "スチームボート・ミッキーズ",
+            "short-name": "スチームボート・ミッキーズ",
             "lat": "35.62501049638865",
             "lon": "139.88711099647574",
             "type": "shop",
-            "nearest_node_id": 33
+            "nearest_node_id": 33,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/622/"
         },
         {
             "spot_id": 83,
             "name": "スリンキー・ドッグのギフトトロリー",
+            "short-name": "スリンキー・ドッグのギフトトロリー",
             "lat": "35.62468223963672",
             "lon": "139.88863096648507",
             "type": "shop",
-            "nearest_node_id": 29
+            "nearest_node_id": 29,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/618/"
         },
         {
             "spot_id": 84,
             "name": "タワー・オブ・テラー・メモラビリア",
+            "short-name": "タワー・オブ・テラー・メモラビリア",
             "lat": "35.623904604027395",
             "lon": "139.8880629781352",
             "type": "shop",
-            "nearest_node_id": 36
+            "nearest_node_id": 36,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/624/"
         },
         {
             "spot_id": 85,
             "name": "ニュージーズ・ノヴェルティ",
+            "short-name": "ニュージーズ・ノヴェルティ",
             "lat": "35.624554730269516",
             "lon": "139.8873323461311",
             "type": "shop",
-            "nearest_node_id": 33
+            "nearest_node_id": 33,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/623/"
         },
         {
             "spot_id": 86,
             "name": "マクダックス・デパートメントストア",
+            "short-name": "マクダックス・デパートメントストア",
             "lat": "35.62508364370584",
             "lon": "139.88749816160015",
             "type": "shop",
-            "nearest_node_id": 24
+            "nearest_node_id": 24,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/621/"
         },
         {
             "spot_id": 87,
             "name": "スカイウォッチャー・スーヴェニア",
+            "short-name": "スカイウォッチャー・スーヴェニア",
             "lat": "35.62548210888883",
             "lon": "139.8819793769745",
             "type": "shop",
-            "nearest_node_id": 58
+            "nearest_node_id": 58,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/631/"
         },
         {
             "spot_id": 88,
             "name": "ディスカバリーギフト",
+            "short-name": "ディスカバリーギフト",
             "lat": "35.62505605408059",
             "lon": "139.88328215942215",
             "type": "shop",
-            "nearest_node_id": 59
+            "nearest_node_id": 59,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/630/"
         },
         {
             "spot_id": 89,
             "name": "エクスペディション・フォトアーカイヴ",
+            "short-name": "エクスペディション・フォトアーカイヴ",
             "lat": "35.62674376338182",
             "lon": "139.88113534998413",
             "type": "shop",
-            "nearest_node_id": 137
+            "nearest_node_id": 137,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/648/"
         },
         {
             "spot_id": 90,
             "name": "ペドラーズ・アウトポスト",
+            "short-name": "ペドラーズ・アウトポスト",
             "lat": "35.6267657690279",
             "lon": "139.88123911760607",
             "type": "shop",
-            "nearest_node_id": 137
+            "nearest_node_id": 137,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/644/"
         },
         {
             "spot_id": 91,
             "name": "ルックアウト・トレーダー",
+            "short-name": "ルックアウト・トレーダー",
             "lat": "35.62694452524924",
             "lon": "139.8814682737277",
             "type": "shop",
-            "nearest_node_id": 138
+            "nearest_node_id": 138,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/647/"
         },
         {
             "spot_id": 92,
             "name": "ロストリバーアウトフィッター",
+            "short-name": "ロストリバーアウトフィッター",
             "lat": "35.62677443516585",
             "lon": "139.88222003262334",
             "type": "shop",
-            "nearest_node_id": 110
+            "nearest_node_id": 110,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/645/"
         },
         {
             "spot_id": 93,
             "name": "アグラバーマーケットプレイス",
+            "short-name": "アグラバーマーケットプレイス",
             "lat": "35.628112961698555",
             "lon": "139.88262954350137",
             "type": "shop",
-            "nearest_node_id": 132
+            "nearest_node_id": 132,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/641/"
         },
         {
             "spot_id": 94,
             "name": "アブーズ・バザール",
+            "short-name": "アブーズ・バザール",
             "lat": "35.62811056149167",
             "lon": "139.88234041804847",
             "type": "shop",
-            "nearest_node_id": 135
+            "nearest_node_id": 135,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/650/"
         },
         {
             "spot_id": 95,
             "name": "キス・デ・ガール・ファッション",
+            "short-name": "キス・デ・ガール・ファッション",
             "lat": "35.62700723497052",
             "lon": "139.88252646975775",
             "type": "shop",
-            "nearest_node_id": 82
+            "nearest_node_id": 82,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/637/"
         },
         {
             "spot_id": 96,
             "name": "グロットフォト＆ギフト",
+            "short-name": "グロットフォト＆ギフト",
             "lat": "35.62746485770061",
             "lon": "139.88382750432524",
             "type": "shop",
-            "nearest_node_id": 109
+            "nearest_node_id": 109,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/638/"
         },
         {
             "spot_id": 97,
             "name": "シータートル・スーヴェニア",
+            "short-name": "シータートル・スーヴェニア",
             "lat": "35.62703183626786",
             "lon": "139.88372426073525",
             "type": "shop",
-            "nearest_node_id": 16
+            "nearest_node_id": 16,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/640/"
         },
         {
             "spot_id": 98,
             "name": "スリーピーホエール・ショップ",
+            "short-name": "スリーピーホエール・ショップ",
             "lat": "35.62669513695009",
             "lon": "139.8826014298775",
             "type": "shop",
-            "nearest_node_id": 0
+            "nearest_node_id": 0,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/633/"
         },
         {
             "spot_id": 99,
             "name": "マーメイドトレジャー",
+            "short-name": "マーメイドトレジャー",
             "lat": "35.626900580215036",
             "lon": "139.882564338146",
             "type": "shop",
-            "nearest_node_id": 82
+            "nearest_node_id": 82,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/636/"
         },
         {
             "spot_id": 100,
             "name": "マーメイドメモリー",
+            "short-name": "マーメイドメモリー",
             "lat": "35.62722882470246",
             "lon": "139.8830465204795",
             "type": "shop",
-            "nearest_node_id": 97
+            "nearest_node_id": 97,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/639/"
         },
         {
             "spot_id": 101,
             "name": "ノーチラスギフト",
+            "short-name": "ノーチラスギフト",
             "lat": "35.626211716413074",
             "lon": "139.88401990748127",
             "type": "shop",
-            "nearest_node_id": 47
+            "nearest_node_id": 47,
+            "url": "https://www.tokyodisneyresort.jp/tds/shop/detail/632/"
         },
         {
             "spot_id": 102,
             "name": "パークエントランス・ノース・チケットブース",
+            "short-name": "エントランス(北)",
             "lat": "35.6276852325185",
             "lon": "139.88856278451385",
             "type": "place",
-            "nearest_node_id": 106
+            "nearest_node_id": 106,
+            "url": "https://www.tokyodisneyresort.jp/tds/service/detail/041/"
         },
         {
             "spot_id": 103,
             "name": "パークエントランス・サウス・チケットブース",
+            "short-name": "エントランス(南)",
             "lat": "35.626630558175975",
             "lon": "139.88994325030163",
             "type": "place",
-            "nearest_node_id": 107
+            "nearest_node_id": 107,
+            "url": "https://www.tokyodisneyresort.jp/tds/service/detail/041/"
         },
         {
             "spot_id": 104,
             "name": "アクアスフィア",
+            "short-name": "アクアスフィア",
             "lat": "35.627009703489286",
             "lon": "139.88911531873848",
             "type": "place",
@@ -870,14 +1078,17 @@
         {
             "spot_id": 105,
             "name": "ディズニーシー・プラザ",
+            "short-name": "ディズニーシー・プラザ",
             "lat": "35.62696701859257",
             "lon": "139.88897013253737",
             "type": "place",
-            "nearest_node_id": 3
+            "nearest_node_id": 3,
+            "url": "https://www.tokyodisneyresort.jp/dream/photo/character/tds_disneysea-plaza.html"
         },
         {
             "spot_id": 106,
             "name": "ミッキー広場",
+            "short-name": "ミッキー広場",
             "lat": "35.626591296757205",
             "lon": "139.88737282135511",
             "type": "place",
@@ -886,47 +1097,57 @@
         {
             "spot_id": 107,
             "name": "ミッキー＆フレンズのハーバーグリーティング",
+            "short-name": "ハーバーグリーティング",
             "lat": "35.626591296757205",
             "lon": "139.88737282135511",
             "type": "show",
             "nearest_node_id": 108,
-            "play-time": "600"
+            "play-time": "600",
+            "url": "https://www.tokyodisneyresort.jp/tds/show/detail/265/"
         },
         {
             "spot_id": 108,
             "name": "ビッグバンドビート～ア・スペシャルトリート～",
+            "short-name": "ビッグバンドビート",
             "lat": "35.62484764083992",
             "lon": "139.88824637236533",
             "type": "show",
             "nearest_node_id": 26,
-            "play-time": "1500"
+            "play-time": "1500",
+            "url": "https://www.tokyodisneyresort.jp/tds/show/detail/975/"
         },
         {
             "spot_id": 109,
             "name": "ディズニー・ライト・ザ・ナイト",
+            "short-name": "ディズニー・ライト・ザ・ナイト",
             "lat": "35.626591296757205",
             "lon": "139.88737282135511",
             "type": "show",
             "nearest_node_id": 108,
-            "play-time": "300"
+            "play-time": "300",
+            "url": "https://www.tokyodisneyresort.jp/tds/show/detail/930/"
         },
         {
             "spot_id": 110,
             "name": "マイ・フレンド・ダッフィー",
+            "short-name": "マイ・フレンド・ダッフィー",
             "lat": "35.62454488725738",
             "lon": "139.88491178287993",
             "type": "show",
             "nearest_node_id": 125,
-            "play-time": "600"
+            "play-time": "600",
+            "url": "https://www.tokyodisneyresort.jp/tds/show/detail/931/"
         },
         {
             "spot_id": 111,
             "name": "ソング・オブ・ミラージュ",
+            "short-name": "ソング・オブ・ミラージュ",
             "lat": "35.625848533170725",
             "lon": "139.88223858921663",
             "type": "show",
             "nearest_node_id": 65,
-            "play-time": "1800"
+            "play-time": "1800",
+            "url": "https://www.tokyodisneyresort.jp/tds/show/detail/927/"
         }
     ]
 }


### PR DESCRIPTION
### 概要
* `/spot/list` に下記を追加
  * スポットの短縮名称(`short-name`)を追加
  * スポットのURL(`url`)を追加
* いずれ、スポットの選択画面でこれらを利用するようにしたい

### 検証
* herokuにデプロイして期待通りの出力となっていることを確認
https://disney-app-api.herokuapp.com/spot/list
<img width="461" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/126054496-65bf09cf-ac45-4878-a31e-890a2f1fe05c.PNG">
