### PR TITLE
待ち時間モードを指定する口をあける

### DIFF
--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -80,6 +80,7 @@ class TravelInputSpot:
 class TravelInput:
     def __init__(self, json_data):
         self.time_mode = ""
+        self.wait_time_mode = ""
         self.specified_time = -1  # 00:00からの経過秒数
         self.walk_speed = ""
         self.start_spot_id = -1
@@ -99,6 +100,20 @@ class TravelInput:
         valid_time_mode_list = ["start", "end"]
         if self.time_mode not in valid_time_mode_list:
             self.error_message = "time-modeはstart/endのいずれかを指定してください。"
+            return False
+        return True
+
+    def __init_wait_time_mode(self, json_data):
+        """
+        wait_time_modeを初期化する。初期化に失敗した場合はFalseを返す。
+        """
+        if not json_data.get("wait-time-mode"):
+            self.error_message = "wait-time-modeが存在しません。"
+            return False
+        self.wait_time_mode = json_data["wait-time-mode"]
+        valid_wait_time_mode_list = ["real", "mean"]
+        if self.wait_time_mode not in valid_wait_time_mode_list:
+            self.error_message = "wait-time-modeはreal/meanのいずれかを指定してください。"
             return False
         return True
 
@@ -247,7 +262,10 @@ class TravelInput:
         return True
 
     def init_by_json(self, json_data):
-        if not self.__init_time_mode(json_data):
+        # note: time-modeはいったんdisableにする
+        # if not self.__init_time_mode(json_data):
+        #     return
+        if not self.__init_wait_time_mode(json_data):
             return
         if not self.__init_specified_time(json_data):
             return


### PR DESCRIPTION
### 概要
https://github.com/Nakajima2nd/disney-app/issues/59
* 待ち時間モード(`wait-time-mode`)を指定する口をあけた
  * `real` : リアルタイム待ち時間を使用
  * `mean` : 平均待ち時間を使用
* 合わせて、出発時間モード(`time-mode`)を指定する口を廃止
* これらは `/search` の仕様書に反映済
  * https://github.com/Nakajima2nd/disney-app/wiki/search-%E3%81%AE%E4%BB%95%E6%A7%98

※このプルリクはIFの口開けのみ。現時点では、 `wait-time-mode` の指定を `mean` にしたとしても、リアルタイム待ち時間が使用される。

### 検証
ローカルで検証し、下記を確認
* `wait-time-mode` が指定されていない場合エラーになる
* `wait-time-mode` が `real` `mean` 以外の場合エラーになる
* `wait-time` が指定されていなくてもエラーにならない