### PR TITLE
短縮名称を使うように修正

### DIFF
--- a/frontend/components/SpotListDialog.jsx
+++ b/frontend/components/SpotListDialog.jsx
@@ -82,6 +82,7 @@ export const SpotListDialog = ({ editing, selected, open, spots, setEditing, set
     const newSpot = pipe(
       assoc('spotId', spot.spotId),
       assoc('name', spot.name),
+      assoc('shortName', spot.shortName),
       assoc('startTime', spot.startTime),
       assoc('step', 1)
     )(editing)

--- a/frontend/components/SpotListDialog.jsx
+++ b/frontend/components/SpotListDialog.jsx
@@ -279,7 +279,7 @@ const SpotList = ({ obj, editing, handleClickSpot }) => {
           onClick={handleClickSpot(spot)}
           selected={editing.name === spot.name}
         >
-          <ListItemText primary={spot.name} />
+          <ListItemText primary={spot.shortName} />
         </ListItem>
       ))}
     </CustomList>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -66,6 +66,7 @@ const DeleteButton = styled(IconButton)`
 const initialEditing = {
   spotId: null,
   name: '',
+  shortName: '',
   desiredArrivalTime: null,
   startTime: null,
   stayTime: '',
@@ -159,7 +160,7 @@ const Home = () => {
             color="primary"
             onClick={handleOpen(spot, index)}
           >
-            {spot.name}
+            {spot.shortName}
           </SpotButton>
           <DeleteButton onClick={handleDelete(index)}>
             <Close />

--- a/frontend/pages/search/index.js
+++ b/frontend/pages/search/index.js
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import { Box, Typography } from '@material-ui/core'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { Error } from '../../components/Error'
 import { Loading } from '../../components/Loading'
 import { useGetSearchResult } from '../../hooks'
 


### PR DESCRIPTION
次の場面で`short-name`を使うように修正
![image](https://user-images.githubusercontent.com/55273685/126883584-41ae211b-9edc-45a7-b720-66d9b4dd9b47.png)

#### 相談
* 探索結果画面でも使いたいので、`/search`のレスポンスにも`short-name`を含めてもらう
* ショーの場合、時間はなくていいのか
* ここも短縮名称でいいよっていうところはあるか