### PR TITLE
/searchの返却に短縮名称をつめる 他

### DIFF
--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -32,6 +32,7 @@ class TourSpot:
     def __init__(self):
         self.spot_id = -1
         self.spot_name = ""
+        self.spot_short_name = ""
         self.lat = ""
         self.lon = ""
         self.type = ""
@@ -42,6 +43,7 @@ class TourSpot:
         ret_dict = dict()
         ret_dict["spot-id"] = self.spot_id
         ret_dict["spot-name"] = self.spot_name
+        ret_dict["short-spot-name"] = self.spot_short_name
         ret_dict["lat"] = self.lat
         ret_dict["lon"] = self.lon
         ret_dict["type"] = self.type

--- a/backend/disneyapp/tsp_solver.py
+++ b/backend/disneyapp/tsp_solver.py
@@ -84,6 +84,7 @@ class RandomTspSolver:
                 "play-time": int(spot_data["play-time"]) if spot_data.get("play-time") else 0,
                 "wait-time": int(spot_data["wait-time"]) if spot_data.get("wait-time") else 0,
                 "name": spot_data["name"],
+                "short-name": spot_data["short-name"],
                 "lat": spot_data["lat"],
                 "lon": spot_data["lon"],
                 "type": spot_data["type"]
@@ -161,6 +162,7 @@ class RandomTspSolver:
             tour_spot = TourSpot()
             tour_spot.spot_id = spot_id
             tour_spot.spot_name = self.spot_data_dict[spot_id]["name"]
+            tour_spot.spot_short_name = self.spot_data_dict[spot_id]["short-name"]
             tour_spot.lat = self.spot_data_dict[spot_id]["lat"]
             tour_spot.lon = self.spot_data_dict[spot_id]["lon"]
             tour_spot.type = self.spot_data_dict[spot_id]["type"]

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -97,6 +97,7 @@ def add_show_dynamic_data_stub(spots_json):
         for show_time in show_time_list:
             show_copied = copy.deepcopy(show)
             show_copied["name"] += ("(" + show_time + ")")
+            show_copied["short-name"] += ("(" + show_time + ")")
             show_copied["start-time"] = show_time
             new_show_list.append(show_copied)
     spots_json["show"] = new_show_list


### PR DESCRIPTION
### 概要
* 下記の2つの対応を実施
  * `/search` の返却に短縮名称(`short-spot-name`)を詰める
  * `/spot/list` で返却するショーの短縮名称に実施時刻を含める

### 検証
* ローカルで実行し期待通りの出力になっていることを確認

search証跡
<img width="880" alt="search" src="https://user-images.githubusercontent.com/33785163/126884742-aa4609ae-754c-435c-b7b4-91b245b007ef.PNG">

spot/list 証跡
<img width="800" alt="spot_list" src="https://user-images.githubusercontent.com/33785163/126884747-af098868-79ca-4d40-9fad-cdd62f226c85.PNG">

