### PR TITLE
同じスポットが複数回指定されている場合に400エラーを返す

### DIFF
--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -243,6 +243,18 @@ class TravelInput:
 
         return travel_input_spot
 
+    @staticmethod
+    def __is_duplicate_spot(spots):
+        """
+        同じスポットが複数回指定されている場合Trueを返す。
+        """
+        spot_set = set()
+        for spot in spots:
+            if spot.spot_id in spot_set:
+                return True
+            spot_set.add(spot.spot_id)
+        return False
+
     def __init_spots(self, json_data):
         """
         spotsを初期化する。初期化に失敗した場合はFalseを返す。
@@ -261,6 +273,9 @@ class TravelInput:
             if not (travel_input_spot := self.__init_spot(spot_json)):
                 return False
             self.spots.append(travel_input_spot)
+        if TravelInput.__is_duplicate_spot(self.spots):
+            self.error_message = "同じスポットが複数回指定されています。"
+            return False
         return True
 
     def init_by_json(self, json_data):


### PR DESCRIPTION
### 概要
https://github.com/Nakajima2nd/disney-app/issues/69
* 同じスポットを複数指定して `/search` を実行した場合、400エラーを返すようにした
  * これまでは 500 エラーが返っていたので、きちんとハンドリングした形

### 検証
本番環境にデプロイし、期待通りのエラーが返ってくることを確認。
* 下記は「ヴェネツィアン・ゴンドラ」を2回指定したリクエスト
https://disney-app-pi.vercel.app/search?param=%257B%2522wait-time-mode%2522%3A%2522real%2522%2C%2522specified-time%2522%3A%252214%3A24%2522%2C%2522walk-speed%2522%3A%2522normal%2522%2C%2522start-spot-id%2522%3A103%2C%2522goal-spot-id%2522%3A103%2C%2522spots%2522%3A%255B%257B%2522spot-id%2522%3A3%257D%2C%257B%2522spot-id%2522%3A9%257D%2C%257B%2522spot-id%2522%3A4%257D%2C%257B%2522spot-id%2522%3A0%257D%2C%257B%2522spot-id%2522%3A3%257D%255D%257D