### PR TITLE
指定待ち時間の考慮が欠けていたバグを修正

### DIFF
--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -77,6 +77,7 @@ class TravelInputSpot:
         self.spot_id = -1
         self.desired_arrival_time = -1  # 00:00 からの経過秒数
         self.stay_time = -1  # [秒]
+        self.specified_wait_time = 0
 
 
 class TravelInput:
@@ -237,6 +238,7 @@ class TravelInput:
             try:
                 # note: 指定された待ち時間の分だけ到着希望時刻を早める
                 travel_input_spot.desired_arrival_time -= int(spot_json["specified-wait-time"]) * 60
+                travel_input_spot.specified_wait_time = int(spot_json["specified-wait-time"]) * 60
             except:
                 self.error_message = "specified-wait-timeには整数を指定してください。"
                 return None

--- a/backend/disneyapp/tsp_solver.py
+++ b/backend/disneyapp/tsp_solver.py
@@ -170,6 +170,18 @@ class RandomTspSolver:
             tour_spot.play_time = self.spot_data_dict[spot_id]["play-time"]
             tour.spots.append(tour_spot)
 
+    @staticmethod
+    def __find_target_spot_from_travel_input(travel_input, target_spot_id):
+        """
+        travel_inputから指定されたspot_idのスポットを検索して返す。
+        指定されたspot_idが存在しない場合はNoneを返す。
+        """
+        spots = travel_input.spots
+        for spot in spots:
+            if spot.spot_id == target_spot_id:
+                return spot
+        return None
+
     def __trace_from_front(self, travel_input, spot_order):
         """
         巡回経路を出発側からTraceし、スポットの到着時刻を算出する。
@@ -206,6 +218,8 @@ class RandomTspSolver:
 
             # dstスポットのイベントを消化するまでの時間を計測
             current_time += max(self.spot_data_dict[dst_spot_id]["wait-time"] * 60, 0)  # note:待ち時間が-1の場合は0にする
+            dst_spot = RandomTspSolver.__find_target_spot_from_travel_input(travel_input, dst_spot_id)
+            current_time += dst_spot.specified_wait_time if dst_spot else 0
             current_time += self.spot_data_dict[dst_spot_id]["play-time"]
             current_time += stay_time if stay_time != -1 else 0
             tour.subroutes.append(subroute)


### PR DESCRIPTION
### 概要
* `/search` において `specified-wait-time` を指定した際の挙動がバグっていたので修正

### 修正内容詳細
* `specified-wait-time` が指定された場合、本来であれば下記の2つの対応が必要
  * ①指定された時間だけ早く目的地に着く
  * ②指定された時間だけ目的地の滞在時間をのばす
    * 例えば指定待ち時間が1時間でショーの時間が15分なら、目的地の滞在時間は1時間15分に伸びる
* ①のみ対応して②の対応が抜けていたため、例えば「1時間」を指定した場合、ショーの時間の1時間前に到着して、ショーが始まる前に該当スポットを出発する経路になってしまっていた

### 検証
* ローカルで `/search` を実行し、期待通りの挙動になっていることを確認