### PR TITLE
スポットの訪問順を最適化しないモードを追加

### DIFF
--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -90,6 +90,7 @@ class TravelInput:
         self.goal_spot_id = -1
         self.spots = []
         self.error_message = ""
+        self.optimize_spot_order = "true"
         self.init_by_json(json_data)
 
     def __init_time_mode(self, json_data):
@@ -280,6 +281,17 @@ class TravelInput:
             return False
         return True
 
+    def __init_optimize_spot_order(self, json_data):
+        if not json_data.get("optimize-spot-order"):
+            self.error_message = "optimize-spot-orderが存在しません。"
+            return False
+        self.optimize_spot_order = json_data["optimize-spot-order"]
+        valid_optimize_spot_order_list = ["true", "false"]
+        if self.optimize_spot_order not in valid_optimize_spot_order_list:
+            self.error_message = "optimize-spot-orderはtrue/falseのいずれかで指定してください。"
+            return False
+        return True
+
     def init_by_json(self, json_data):
         # note: time-modeはいったんdisableにする
         # if not self.__init_time_mode(json_data):
@@ -293,5 +305,7 @@ class TravelInput:
         if not self.__init_start_spot_id(json_data):
             return
         if not self.__init_goal_spot_id(json_data):
+            return
+        if not self.__init_optimize_spot_order(json_data):
             return
         self.__init_spots(json_data)

--- a/backend/disneyapp/tsp_solver.py
+++ b/backend/disneyapp/tsp_solver.py
@@ -47,6 +47,15 @@ class RandomTspSolver:
             巡回探索の出力オブジェクト。
         """
         self.spot_data_dict = RandomTspSolver.__make_spot_data_dict(travel_input.wait_time_mode)
+        if travel_input.optimize_spot_order == "true":
+            return self.__make_tour_by_optimizing_spot_order(travel_input)
+        else:
+            return self.__make_tour_from_original_spot_order(travel_input)
+
+    def __make_tour_by_optimizing_spot_order(self, travel_input):
+        """
+        スポットの並び順を最適化することによって巡回路を生成する。
+        """
         base_tour = [ travel_input_spot.spot_id for travel_input_spot in travel_input.spots ]
         current_best_score = 9999999999999
         current_best_tour = None
@@ -64,6 +73,18 @@ class RandomTspSolver:
             return None
         return self.__build_tour(travel_input, current_best_tour)
 
+    def __make_tour_from_original_spot_order(self, travel_input):
+        """
+        入力された順にスポットを並べて巡回路を構築する。
+        """
+        base_tour = [travel_input_spot.spot_id for travel_input_spot in travel_input.spots]
+        current_tour_with_od = [travel_input.start_spot_id] + base_tour + [travel_input.goal_spot_id]
+        tour = self.__trace_from_front(travel_input, current_tour_with_od)
+        score = self.__eval_spot_list_order(tour)
+        if score > 3600 * 24:
+            # 時刻制約を満たす経路にならない場合はNoneを返す
+            return None
+        return self.__build_tour(travel_input, current_tour_with_od)
 
     @staticmethod
     def __make_spot_data_dict(wait_time_mode):


### PR DESCRIPTION
**このプルリクで `/search` の必須パラメタに破壊的な変更が入っている。（必須パラメタの追加）**
そのためフロントの対応を入れないと `/search` でエラーになるため注意。

### 概要
* `/search` のパラメタに下記を追加
  * `optimize-spot-order` : "true" or "false"
    * スポットの訪問順序を最適化するか否かを指定する
    * "true" を指定するとこれまでの巡回探索と同じ挙動になる
* この「訪問順序を最適化しない」探索は以下の2つの用途で用いる予定
  * アプリの一番最初の画面で、ユーザに「スポットの訪問順序を最適化するか否か」を選択させる際に利用する
  * 経路の待ち時間のみ更新するAPIとして利用する