### PR TITLE
hh:mm:ss形式の時刻指定も許容する

### DIFF
--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -131,8 +131,8 @@ class TravelInput:
         specified_time_str = json_data["specified-time"]
         try:
             # hh:mm -> 秒数 への変換
-            splited_time_str = specified_time_str.split(":")
-            self.specified_time = int(splited_time_str[0]) * 3600 + int(splited_time_str[1]) * 60
+            split_time_str = specified_time_str.split(":")
+            self.specified_time = int(split_time_str[0]) * 3600 + int(split_time_str[1]) * 60
         except:
             self.error_message = "時間の形式が不正です。hh:mm形式で指定してください。"
             return False

--- a/backend/disneyapp/models.py
+++ b/backend/disneyapp/models.py
@@ -131,8 +131,8 @@ class TravelInput:
         specified_time_str = json_data["specified-time"]
         try:
             # hh:mm -> 秒数 への変換
-            hh_str, mm_str = specified_time_str.split(":")
-            self.specified_time = int(hh_str) * 3600 + int(mm_str) * 60
+            splited_time_str = specified_time_str.split(":")
+            self.specified_time = int(splited_time_str[0]) * 3600 + int(splited_time_str[1]) * 60
         except:
             self.error_message = "時間の形式が不正です。hh:mm形式で指定してください。"
             return False


### PR DESCRIPTION
### 概要
* こちらのissueの対応
  * https://github.com/Nakajima2nd/disney-app/issues/78
* 出発時刻として `hh:mm:ss` 形式の文字列が指定された場合、ss部分を落とすように改修

### 検証
* production環境にデプロイし、Galaxyブラウザから経路探索を実行し成功することを確認
* 出発時刻指定が `hh:mm:ss` 形式のリクエストで探索が成功することを確認
<img width="630" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/129470517-3c39fe2a-b8a7-4f41-90c8-415f97d790e0.PNG">