### PR TITLE
動的な情報をGASではなくDBから取得する　他

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -114,7 +114,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-# .env
+.env
 .env/
 .venv/
 env/

--- a/backend/disneyapp/algorithm/models.py
+++ b/backend/disneyapp/algorithm/models.py
@@ -1,4 +1,4 @@
-from disneyapp.data_manager import StaticDataManager
+from disneyapp.data.data_manager import StaticDataManager
 
 
 class Subroute:
@@ -84,6 +84,9 @@ class TravelInputSpot:
 
 
 class TravelInput:
+    """
+    /search の入力情報を保持するクラス。入力情報のバリデーションもこのクラスで実施する。
+    """
     def __init__(self, json_data):
         self.time_mode = ""
         self.wait_time_mode = ""

--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -1,5 +1,5 @@
-from disneyapp.data_manager import StaticDataManager, CombinedDatamanager
-from disneyapp.models import Tour, TourSpot, Subroute, TravelInput
+from disneyapp.data.data_manager import StaticDataManager, CombinedDatamanager
+from disneyapp.algorithm.models import Tour, TourSpot, Subroute
 import random, copy
 
 

--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -1,4 +1,5 @@
-from disneyapp.data.data_manager import StaticDataManager, CombinedDatamanager
+from disneyapp.data.data_manager import StaticDataManager
+from disneyapp.data.spot_list_data_converter import SpotListDataConverter
 from disneyapp.algorithm.models import Tour, TourSpot, Subroute
 import random, copy
 
@@ -98,7 +99,7 @@ class RandomTspSolver:
                 real -> リアルタイム待ち時間
                 mean -> 平均待ち時間
         """
-        combined_spot_data = CombinedDatamanager.get_combined_spot_data()
+        combined_spot_data = SpotListDataConverter.get_merged_spot_data()
         spot_data_dict = {}
         for spot_data in combined_spot_data:
             spot_data_elem = {

--- a/backend/disneyapp/data/data_manager.py
+++ b/backend/disneyapp/data/data_manager.py
@@ -15,8 +15,8 @@ class DynamicDataManager:
     def fetch_latest_data(cls):
         current_time = int(time.time())
         # 前回データ取得時から5分以内であれば前回取得データを使いまわす
-        # if current_time - cls.prev_fetch_time < 300:
-        #     return cls.prev_fetch_data
+        if current_time - cls.prev_fetch_time < 300:
+            return cls.prev_fetch_data
         cls.prev_fetch_time = current_time
         url = DynamicDataManager.GAS_URL
         req = urllib.request.Request(url)

--- a/backend/disneyapp/data/db_handler.py
+++ b/backend/disneyapp/data/db_handler.py
@@ -1,5 +1,6 @@
 import os
 import psycopg2
+import json
 from dotenv import load_dotenv
 from psycopg2.extras import DictCursor
 
@@ -15,8 +16,13 @@ class DBHandler:
         if not self.database_url:
             self.database_url = str(os.environ['DATABASE_URL'])
 
-    def get_single_record(self, table_name):
+    def fetch_latest_dynamic_data(self, table_name):
+        """
+        最新の動的情報をDBから取得し、Jsonオブジェクトに変換して返す。
+        """
         with psycopg2.connect(self.database_url, sslmode='require') as conn:
             with conn.cursor(cursor_factory=DictCursor) as cur:
-                cur.execute("SELECT * FROM " + table_name + " ORDER BY updated_time DESC")
-                return cur.fetchone()
+                cur.execute("SELECT data FROM " + table_name + " ORDER BY datetime DESC")
+                latest_dynamic_record = cur.fetchone()
+                return json.loads(latest_dynamic_record["data"])
+

--- a/backend/disneyapp/data/models.py
+++ b/backend/disneyapp/data/models.py
@@ -38,7 +38,7 @@ class AttractionSpotInfo:
         self.enable = False if obj["disable-flag"] else True
         self.wait_time = int(obj["wait-time"])
         self.mean_wait_time = int(obj["mean-wait-time"])
-        self.sp_status = obj["sp-status"] if obj.get("sp-status") else ""
+        self.sp_status = obj["standby-pass-status"]
         self.status = obj["status"]
         self.start_time = obj["start-time"]
         self.end_time = obj["end-time"]

--- a/backend/disneyapp/data/models.py
+++ b/backend/disneyapp/data/models.py
@@ -1,0 +1,341 @@
+
+class AttractionSpotInfo:
+    """
+    spot/list で返却するアトラクション情報のクラス。
+    """
+    def __init__(self):
+        # static data
+        self.spot_id = -1
+        self.name = ""
+        self.short_name = ""
+        self.lat = ""
+        self.lon = ""
+        self.play_time = -1
+        self.url = ""
+        self.area = ""
+        self.speed_thrill = "false"
+        # dynamic data
+        self.enable = True
+        self.wait_time = -1
+        self.mean_wait_time = -1
+        self.sp_status = ""
+        self.status = ""
+        self.start_time = ""
+        self.end_time = ""
+
+    def set_static_data(self, obj):
+        self.spot_id = obj["spot-id"]
+        self.name = obj["name"]
+        self.short_name = obj["short-name"]
+        self.lat = obj["lat"]
+        self.lon = obj["lon"]
+        self.play_time = obj["play-time"] if obj.get("play-time") else -1
+        self.url = obj["url"]
+        self.area = obj["area"]
+        self.speed_thrill = obj["speed-thrill"]
+
+    def set_dynamic_data(self, obj):
+        self.enable = False if obj["disable-flag"] else True
+        self.wait_time = int(obj["wait-time"])
+        self.mean_wait_time = int(obj["mean-wait-time"])
+        self.sp_status = obj["sp-status"] if obj.get("sp-status") else ""
+        self.status = obj["status"]
+        self.start_time = obj["start-time"]
+        self.end_time = obj["end-time"]
+
+    def to_dict(self):
+        return [{
+            "spot-id": self.spot_id,
+            "name": self.name,
+            "short-name": self.short_name,
+            "lat": self.lat,
+            "lon": self.lon,
+            "play-time": self.play_time,
+            "url": self.url,
+            "area": self.area,
+            "speed-thrill": self.speed_thrill,
+            "enable": self.enable,
+            "wait-time": self.wait_time,
+            "mean-wait-time": self.mean_wait_time,
+            "sp-status": self.sp_status,
+            "status": self.status,
+            "start-time": self.start_time,
+            "end-time": self.end_time,
+            "type": "attraction"
+        }]
+
+
+class RestaurantSpotInfo:
+    """
+    spot/list で返却するレストラン情報のクラス。
+    """
+    def __init__(self):
+        # static data
+        self.spot_id = -1
+        self.name = ""
+        self.short_name = ""
+        self.lat = ""
+        self.lon = ""
+        self.url = ""
+        self.menu_url = ""
+        self.can_reserve = "false"
+        self.area = ""
+        self.menu_type = []
+        self.budget_day = ""
+        self.budget_night = ""
+        self.seats = ""
+        # dynamic data
+        self.enable = True
+        self.wait_time = -1
+        self.mean_wait_time = -1
+        self.status = ""
+        self.start_time = ""
+        self.end_time = ""
+
+    def set_static_data(self, obj):
+        self.spot_id = obj["spot-id"]
+        self.name = obj["name"]
+        self.short_name = obj["short-name"]
+        self.lat = obj["lat"]
+        self.lon = obj["lon"]
+        self.url = obj["url"]
+        self.menu_url = obj["menu-url"]
+        self.can_reserve = obj["can-reserve"]
+        self.area = obj["area"]
+        self.menu_type = obj["menu-type"]
+        self.budget_day = obj["budget-day"]
+        self.budget_night = obj["budget-night"]
+        self.seats = obj["seats"]
+
+    def set_dynamic_data(self, obj):
+        self.enable = False if obj["disable-flag"] else True
+        self.wait_time = int(obj["wait-time"])
+        self.mean_wait_time = int(obj["mean-wait-time"])
+        self.status = obj["status"]
+        self.start_time = obj["start-time"]
+        self.end_time = obj["end-time"]
+
+    def to_dict(self):
+        return [{
+            "spot-id": self.spot_id,
+            "name": self.name,
+            "short-name": self.short_name,
+            "lat": self.lat,
+            "lon": self.lon,
+            "url": self.url,
+            "menu-url": self.menu_url,
+            "can-reserve": self.can_reserve,
+            "area": self.area,
+            "menu-type": self.menu_type,
+            "budget-day": self.budget_day,
+            "budget-night": self.budget_night,
+            "seats": self.seats,
+            "enable": self.enable,
+            "wait-time": self.wait_time,
+            "mean-wait-time": self.mean_wait_time,
+            "status": self.status,
+            "start-time": self.start_time,
+            "end-time": self.end_time,
+            "type": "restaurant"
+        }]
+
+
+class ShowSpotInfo:
+    """
+    spot/list で返却するショー情報のクラス。
+    """
+    def __init__(self):
+        # static data
+        self.spot_id = -1
+        self.name = ""
+        self.short_name = ""
+        self.lat = ""
+        self.lon = ""
+        self.play_time = -1
+        self.url = ""
+        self.area = ""
+        # dynamic data
+        self.enable = True
+        self.next_start_time = ""
+        self.start_time_list = []
+
+    def set_static_data(self, obj):
+        self.spot_id = obj["spot-id"]
+        self.name = obj["name"]
+        self.short_name = obj["short-name"]
+        self.lat = obj["lat"]
+        self.lon = obj["lon"]
+        self.play_time = obj["play-time"] if obj.get("play-time") else -1
+        self.url = obj["url"]
+        self.area = obj["area"]
+
+    def set_dynamic_data(self, obj):
+        self.enable = False if obj["disable-flag"] else True
+        self.next_start_time = obj["next-start-time"]
+        self.start_time_list = obj["start-time-list"]
+
+    def to_dict(self):
+        ret_list = []
+        for start_time in self.start_time_list:
+            ret_list.append(
+                {
+                    "spot-id": self.spot_id,
+                    "name": self.name + "(" + start_time + ")",
+                    "short-name": self.short_name + "(" + start_time + ")",
+                    "lat": self.lat,
+                    "lon": self.lon,
+                    "play-time": self.play_time,
+                    "url": self.url,
+                    "area": self.area,
+                    "enable": self.enable,
+                    "next-start-time": self.next_start_time,
+                    "start-time": start_time,
+                    "type": "show"
+                }
+            )
+        return ret_list
+
+
+class GreetingSpotInfo:
+    """
+    spot/list で返却するグリーティング情報のクラス。
+    """
+    def __init__(self):
+        # static data
+        self.spot_id = -1
+        self.name = ""
+        self.short_name = ""
+        self.lat = ""
+        self.lon = ""
+        self.play_time = -1
+        self.url = ""
+        self.area = ""
+        self.character = ""
+        # dynamic data
+        self.enable = True
+        self.standby_pass_status = ""
+        self.wait_time = -1
+        self.mean_wait_time = -1
+        self.status = ""
+        self.start_time = ""
+        self.end_time = ""
+
+    def set_static_data(self, obj):
+        self.spot_id = obj["spot-id"]
+        self.name = obj["name"]
+        self.short_name = obj["short-name"]
+        self.lat = obj["lat"]
+        self.lon = obj["lon"]
+        self.play_time = obj["play-time"] if obj.get("play-time") else -1
+        self.url = obj["url"]
+        self.area = obj["area"]
+        self.character = obj["character"]
+
+    def set_dynamic_data(self, obj):
+        self.enable = False if obj["disable-flag"] else True
+        self.standby_pass_status = obj["standby-pass-status"]
+        self.wait_time = int(obj["wait-time"])
+        self.mean_wait_time = int(obj["mean-wait-time"])
+        self.status = obj["status"]
+        self.start_time = obj["start-time"]
+        self.end_time = obj["end-time"]
+
+    def to_dict(self):
+        return [{
+            "spot-id": self.spot_id,
+            "name": self.name,
+            "short-name": self.short_name,
+            "lat": self.lat,
+            "lon": self.lon,
+            "play-time": self.play_time,
+            "url": self.url,
+            "area": self.area,
+            "character": self.character,
+            "enable": self.enable,
+            "standby-pass-status": self.standby_pass_status,
+            "wait-time": self.wait_time,
+            "mean-wait-time": self.mean_wait_time,
+            "status": self.status,
+            "start-time": self.start_time,
+            "end-time": self.end_time,
+            "type": "greeting"
+        }]
+
+
+class ShopSpotInfo:
+    """
+    spot/list で返却するショップ情報のクラス。
+    """
+
+    def __init__(self):
+        self.spot_id = -1
+        self.name = ""
+        self.short_name = ""
+        self.lat = ""
+        self.lon = ""
+        self.url = ""
+        self.area = ""
+
+    def set_static_data(self, obj):
+        self.spot_id = obj["spot-id"]
+        self.name = obj["name"]
+        self.short_name = obj["short-name"]
+        self.lat = obj["lat"]
+        self.lon = obj["lon"]
+        self.url = obj["url"]
+        self.area = obj["area"]
+
+    def set_dynamic_data(self, obj):
+        # shopは動的情報は存在しない
+        pass
+
+    def to_dict(self):
+        return [{
+            "spot-id": self.spot_id,
+            "name": self.name,
+            "short-name": self.short_name,
+            "lat": self.lat,
+            "lon": self.lon,
+            "url": self.url,
+            "area": self.area,
+            "type": "shop"
+        }]
+
+
+class PlaceSpotInfo:
+    """
+    spot/list で返却するプレイス情報のクラス。
+    """
+    def __init__(self):
+        self.spot_id = -1
+        self.name = ""
+        self.short_name = ""
+        self.lat = ""
+        self.lon = ""
+        self.url = ""
+        self.area = ""
+
+    def set_static_data(self, obj):
+        self.spot_id = obj["spot-id"]
+        self.name = obj["name"]
+        self.short_name = obj["short-name"]
+        self.lat = obj["lat"]
+        self.lon = obj["lon"]
+        self.url = obj["url"] if obj.get("url") else ""
+        self.area = obj["area"]
+
+    def set_dynamic_data(self, obj):
+        # placeは動的情報は存在しない
+        pass
+
+    def to_dict(self):
+        return [{
+            "spot-id": self.spot_id,
+            "name": self.name,
+            "short-name": self.short_name,
+            "lat": self.lat,
+            "lon": self.lon,
+            "url": self.url,
+            "area": self.area,
+            "type": "place"
+        }]

--- a/backend/disneyapp/data/spot_list_data_converter.py
+++ b/backend/disneyapp/data/spot_list_data_converter.py
@@ -1,0 +1,34 @@
+from disneyapp.data.data_manager import StaticDataManager, DynamicDataManager
+from disneyapp.data.models import AttractionSpotInfo, RestaurantSpotInfo, GreetingSpotInfo, ShopSpotInfo, ShowSpotInfo, PlaceSpotInfo
+
+
+class SpotListDataConverter:
+    @staticmethod
+    def select_spot_info_class(static_spot_data):
+        type = static_spot_data["type"]
+        if type == "attraction":
+            return AttractionSpotInfo()
+        elif type == "restaurant":
+            return RestaurantSpotInfo()
+        elif type == "show":
+            return ShowSpotInfo()
+        elif type == "greeting":
+            return GreetingSpotInfo()
+        elif type == "shop":
+            return ShopSpotInfo()
+        else:
+            return PlaceSpotInfo()
+
+    @staticmethod
+    def get_merged_spot_data():
+        spot_static_data_list = StaticDataManager.get_spots()
+        spot_dynamic_data = DynamicDataManager.fetch_latest_data()
+        merged_spot_data_list = []
+        for static_spot_data in spot_static_data_list:
+            merged_spot_data = SpotListDataConverter.select_spot_info_class(static_spot_data)
+            merged_spot_data.set_static_data(static_spot_data)
+            spot_name = static_spot_data["name"]
+            if spot_dynamic_data.get(spot_name):
+                merged_spot_data.set_dynamic_data(spot_dynamic_data[spot_name])
+            merged_spot_data_list.extend(merged_spot_data.to_dict())
+        return merged_spot_data_list

--- a/backend/disneyapp/data_manager.py
+++ b/backend/disneyapp/data_manager.py
@@ -15,8 +15,8 @@ class DynamicDataManager:
     def fetch_latest_data(cls):
         current_time = int(time.time())
         # 前回データ取得時から5分以内であれば前回取得データを使いまわす
-        if current_time - cls.prev_fetch_time < 300:
-            return cls.prev_fetch_data
+        # if current_time - cls.prev_fetch_time < 300:
+        #     return cls.prev_fetch_data
         cls.prev_fetch_time = current_time
         url = DynamicDataManager.GAS_URL
         req = urllib.request.Request(url)

--- a/backend/disneyapp/db_handler.py
+++ b/backend/disneyapp/db_handler.py
@@ -1,0 +1,23 @@
+import datetime
+import os
+import psycopg2
+from dotenv import load_dotenv
+from psycopg2.extras import DictCursor
+
+
+class DBHandler:
+    def __init__(self):
+        load_dotenv()
+        self.database_url = ""
+        self.__init_database_url()
+
+    def __init_database_url(self):
+        self.database_url = os.getenv('DATABASE_URL')
+        if not self.database_url:
+            self.database_url = str(os.environ['DATABASE_URL'])
+
+    def get_single_record(self, table_name):
+        with psycopg2.connect(self.database_url, sslmode='require') as conn:
+            with conn.cursor(cursor_factory=DictCursor) as cur:
+                cur.execute("SELECT * FROM " + table_name + " ORDER BY updated_time DESC")
+                return cur.fetchone()

--- a/backend/disneyapp/db_handler.py
+++ b/backend/disneyapp/db_handler.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import psycopg2
 from dotenv import load_dotenv

--- a/backend/disneyapp/urls.py
+++ b/backend/disneyapp/urls.py
@@ -4,5 +4,6 @@ from . import views
 
 urlpatterns = [
     path('spot/list', views.spot_list, name="spot_list"),
-    path('search', views.search, name="search")
+    path('search', views.search, name="search"),
+    path('sample', views.sample, name="sample")
 ]

--- a/backend/disneyapp/urls.py
+++ b/backend/disneyapp/urls.py
@@ -5,6 +5,5 @@ from . import views
 urlpatterns = [
     path('spot/list', views.spot_list, name="spot_list"),
     path('search', views.search, name="search"),
-    path('sample', views.sample, name="sample"),
-    path('sample2', views.sample2, name="sample2")
+    path('sample', views.sample, name="sample")
 ]

--- a/backend/disneyapp/urls.py
+++ b/backend/disneyapp/urls.py
@@ -4,6 +4,5 @@ from . import views
 
 urlpatterns = [
     path('spot/list', views.spot_list, name="spot_list"),
-    path('search', views.search, name="search"),
-    path('sample', views.sample, name="sample")
+    path('search', views.search, name="search")
 ]

--- a/backend/disneyapp/urls.py
+++ b/backend/disneyapp/urls.py
@@ -5,5 +5,6 @@ from . import views
 urlpatterns = [
     path('spot/list', views.spot_list, name="spot_list"),
     path('search', views.search, name="search"),
-    path('sample', views.sample, name="sample")
+    path('sample', views.sample, name="sample"),
+    path('sample2', views.sample2, name="sample2")
 ]

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -5,7 +5,7 @@ import copy, json
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from rest_framework import status
-from db_handler import DBHandler
+from disneyapp.db_handler import DBHandler
 
 @api_view(["GET"])
 def sample(request):

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -5,7 +5,13 @@ import copy, json
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from rest_framework import status
+from db_handler import DBHandler
 
+@api_view(["GET"])
+def sample(request):
+    db_handler = DBHandler()
+    record = db_handler.get_single_record("raw_html")
+    return Response(record)
 
 @api_view(["GET", "POST"])
 def spot_list(request):

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -1,4 +1,4 @@
-from disneyapp.data_manager import CombinedDatamanager
+from disneyapp.data_manager import CombinedDatamanager,DynamicDataManager
 from disneyapp.models import TravelInput
 from disneyapp.tsp_solver import RandomTspSolver
 import copy, json
@@ -12,6 +12,11 @@ def sample(request):
     db_handler = DBHandler()
     record = db_handler.get_single_record("raw_html")
     return Response(record)
+
+@api_view(["GET"])
+def sample2(request):
+    data = DynamicDataManager.fetch_latest_data()
+    return Response(data)
 
 @api_view(["GET", "POST"])
 def spot_list(request):

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -1,22 +1,12 @@
-from disneyapp.data_manager import CombinedDatamanager,DynamicDataManager
-from disneyapp.models import TravelInput
-from disneyapp.tsp_solver import RandomTspSolver
+from disneyapp.data.data_manager import CombinedDatamanager
+from disneyapp.algorithm.models import TravelInput
+from disneyapp.algorithm.tsp_solver import RandomTspSolver
 import copy, json
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from rest_framework import status
-from disneyapp.db_handler import DBHandler
+from disneyapp.data.db_handler import DBHandler
 
-@api_view(["GET"])
-def sample(request):
-    db_handler = DBHandler()
-    record = db_handler.get_single_record("raw_html")
-    return Response(record)
-
-@api_view(["GET"])
-def sample2(request):
-    data = DynamicDataManager.fetch_latest_data()
-    return Response(data)
 
 @api_view(["GET", "POST"])
 def spot_list(request):
@@ -25,6 +15,13 @@ def spot_list(request):
     spots_json_edited = edit_static_spots_data(filtered_spot_list)
     add_show_dynamic_data = add_show_dynamic_data_stub(spots_json_edited)
     return Response(add_show_dynamic_data)
+
+
+@api_view(["GET"])
+def sample(request):
+    db_handler = DBHandler()
+    latest_dynamic_data = db_handler.fetch_latest_dynamic_data(table_name="sea_dynamic_data")
+    return Response(latest_dynamic_data)
 
 
 @api_view(["POST"])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,5 @@ djangorestframework
 django-cors-headers
 gunicorn
 django-heroku
+psycopg2-binary
+python-dotenv


### PR DESCRIPTION
### 概要
* `/spot/list` で返却するスポット情報について、下記の2つの対応を実施
  * スポットの動的な情報をGASではなくDBから取得する
  * スポットの動的な情報を新規で取得する

それぞれの対応の詳細を下記に記載する。
なお、ここで「動的な情報」と言っているのは、スクレイピングで取得する情報のことを指す。
対義語が「静的な情報」で、五十嵐が手整備しリポジトリにコミットしている情報（スポットの緯度経度など）を指す。

### 動的な情報をDBから取得
* これまではスクレイピング結果をGoogleスプレッドシートに保存し、DjangoからGASで取得する構成になっていたが、パフォーマンスが課題になっていた
* 今回の対応からHeroku DB(DBサーバはPosgreSql)を利用する構成に変更
* スクレイピング内容は下記から確認できる
  * https://data.heroku.com/dataclips/hwlzzkrsxoanwmvydlthualbefhn
* この対応によって、`/spot/list` のレスポンスタイムが `2.9s -> 1.4s` 程度に高速化した
* すでにproduction環境に反映されているので確認できる状態
* ただ、この対応を入れてもなおアプリの起動はもっさりしている印象なので、何かしらフロント側の対応をしていってもいいかも（`/spot/list` の結果返却を待たずにレンダリングを開始するとか・・・。要相談）

### 動的な情報を新規に取得
* これまではアトラクションのみ待ち時間情報をスクレイピングしていたが、ショー、レストラン、グリーティングなどもスクレイピングするように拡張した
* 主な追加属性は下記のとおり
  * `wait-time`, `mean-wait-time`, `enable` (show, restaurant, greetingに新規追加)
  * `status`（該当スポットのステータス）
  * `start-time`（該当スポットの開始時間）
  * `end-time`（該当スポットの終了時間）
* これらの変更はすべてAPI仕様書に反映済
  * https://github.com/Nakajima2nd/disney-app/wiki/API%E4%BB%95%E6%A7%98%E6%9B%B8#output-1
* 今回の対応でスクレイピングできる情報はすべてし切ったと思われる