### PR TITLE
到着希望時刻を破った場合にも一番マシな経路を返すようにする

### DIFF
--- a/backend/disneyapp/algorithm/models.py
+++ b/backend/disneyapp/algorithm/models.py
@@ -68,7 +68,7 @@ class Tour:
         ret_dict = dict()
         ret_dict["start-time"] = self.start_time
         ret_dict["goal-time"] = self.goal_time
-        ret_dict["violate-goal-desired-arrival-time"] = self.violate_desired_arrival_time
+        ret_dict["violate-desired-arrival-time"] = self.violate_desired_arrival_time
         ret_dict["spots"] = []
         for spot in self.spots:
             ret_dict["spots"].append(spot.to_dict())

--- a/backend/disneyapp/algorithm/models.py
+++ b/backend/disneyapp/algorithm/models.py
@@ -28,6 +28,7 @@ class Subroute:
             pair = [ coord[0], coord[1] ]
             ret_dict["coords"].append(pair)
         ret_dict["surplus-wait-time"] = self.surplus_wait_time
+        ret_dict["violate-goal-desired-arrival-time"] = self.violate_goal_desired_arrival_time
         return ret_dict
 
 
@@ -61,11 +62,13 @@ class Tour:
         self.goal_time = ""   # hh:mm
         self.spots = []
         self.subroutes = []
+        self.violate_desired_arrival_time = False
 
     def to_dict(self):
         ret_dict = dict()
         ret_dict["start-time"] = self.start_time
         ret_dict["goal-time"] = self.goal_time
+        ret_dict["violate-goal-desired-arrival-time"] = self.violate_desired_arrival_time
         ret_dict["spots"] = []
         for spot in self.spots:
             ret_dict["spots"].append(spot.to_dict())

--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -82,9 +82,6 @@ class RandomTspSolver:
         current_tour_with_od = [travel_input.start_spot_id] + base_tour + [travel_input.goal_spot_id]
         tour = self.__trace_from_front(travel_input, current_tour_with_od)
         score = self.__eval_spot_list_order(tour)
-        if score > 3600 * 24:
-            # 時刻制約を満たす経路にならない場合はNoneを返す
-            return None
         return self.__build_tour(travel_input, current_tour_with_od)
 
     @staticmethod
@@ -147,10 +144,10 @@ class RandomTspSolver:
         """
         hh_str, mm_str = tour.goal_time.split(":")
         score = int(hh_str) * 3600 + int(mm_str) * 60
-        # 到着希望時刻を1つ破るごとに24時間のペナルティ
+        # 到着希望時刻を1つ破るごとに1時間のペナルティ
         for subroute in tour.subroutes:
             if subroute.violate_goal_desired_arrival_time:
-                score += 3600 * 24
+                score += 3600
         return score
 
     def __build_tour(self, travel_input, spot_order):
@@ -235,7 +232,9 @@ class RandomTspSolver:
                     stay_time = spot.stay_time
             if desired_arrival_time != -1:
                 subroute.violate_goal_desired_arrival_time = (current_time - desired_arrival_time > 0)
-                subroute.surplus_wait_time = desired_arrival_time - current_time
+                if subroute.violate_goal_desired_arrival_time:
+                    tour.violate_desired_arrival_time = True
+                subroute.surplus_wait_time = max(desired_arrival_time - current_time, 0)
                 current_time = max(current_time, desired_arrival_time)
             subroute.goal_time = sec_to_hhmm(current_time)
 


### PR DESCRIPTION
### 概要
* `/search` の仕様を変更
* これまでは到着希望時刻をすべて満たすような経路を見つけられなかった場合エラーを返していた
* 今回の対応で、そのような経路を見つけられなかったとしても、一番マシな経路を返すようにした
  * 1件でも到着希望時刻を破っている場合には `violate-desired-arrival-time` 属性が `true` になるため検出可能
  * 到着希望時刻を破っているSubrouteについては `violate-goal-desired-arrival-time` が `true` になる

### 検証
ローカルで期待通りの挙動になることを確認。

入力（spot 0とspot 3の希望時刻を同時に満たすことができない）
```
{
	"wait-time-mode": "real",
	"specified-time": "15:00",
	"walk-speed": "normal",
	"start-spot-id": 103,
	"goal-spot-id": 103,
        "optimize-spot-order": "true",
	"spots": [
		{
			"spot-id": 0,
                        "desired-arrival-time": "16:00"
		},
		{
			"spot-id": 3,
                        "desired-arrival-time": "16:20"
		},
		{
			"spot-id": 4
		}
	]
}
```

出力（spot 3の到着希望時刻を破っているため、該当のフラグがtrueになっている）
<img width="501" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/131210583-aca58bc4-de75-4ed1-9acb-d09470ba7ab3.PNG">
