### PR TITLE
スポットの営業時間を考慮して巡回経路を求める

### DIFF
--- a/backend/disneyapp/algorithm/models.py
+++ b/backend/disneyapp/algorithm/models.py
@@ -42,6 +42,9 @@ class TourSpot:
         self.type = ""
         self.play_time = -1 # sec
         self.wait_time = -1
+        self.arrival_time = ""
+        self.depart_time = ""
+        self.violate_business_hours = False
 
     def to_dict(self):
         ret_dict = dict()
@@ -53,6 +56,9 @@ class TourSpot:
         ret_dict["type"] = self.type
         ret_dict["play-time"] = self.play_time
         ret_dict["wait-time"] = self.wait_time
+        ret_dict["arrival-time"] = self.arrival_time
+        ret_dict["depart-time"] = self.depart_time
+        ret_dict["violate-business-hours"] = self.violate_business_hours
         return ret_dict
 
 
@@ -63,12 +69,16 @@ class Tour:
         self.spots = []
         self.subroutes = []
         self.violate_desired_arrival_time = False
+        self.violate_business_hours = False
+        self.cost = -1
 
     def to_dict(self):
         ret_dict = dict()
         ret_dict["start-time"] = self.start_time
         ret_dict["goal-time"] = self.goal_time
         ret_dict["violate-desired-arrival-time"] = self.violate_desired_arrival_time
+        ret_dict["violate-business-hours"] = self.violate_business_hours
+        ret_dict["cost"] = self.cost
         ret_dict["spots"] = []
         for spot in self.spots:
             ret_dict["spots"].append(spot.to_dict())

--- a/backend/disneyapp/data/spot_list_data_converter.py
+++ b/backend/disneyapp/data/spot_list_data_converter.py
@@ -20,7 +20,13 @@ class SpotListDataConverter:
             return PlaceSpotInfo()
 
     @staticmethod
-    def get_merged_spot_data():
+    def get_merged_spot_data_list():
+        """
+        静的データと動的データを、スポット名称をキーにマージして返す。
+
+        Returns: array-like
+            スポット情報のリスト。
+        """
         spot_static_data_list = StaticDataManager.get_spots()
         spot_dynamic_data = DynamicDataManager.fetch_latest_data()
         merged_spot_data_list = []
@@ -32,3 +38,15 @@ class SpotListDataConverter:
                 merged_spot_data.set_dynamic_data(spot_dynamic_data[spot_name])
             merged_spot_data_list.extend(merged_spot_data.to_dict())
         return merged_spot_data_list
+
+    @staticmethod
+    def get_merged_spot_data_dict():
+        """
+        静的データと動的データをマージし、spot-idをキーにしたdictにして返す。
+        """
+        merged_spot_data_list = SpotListDataConverter.get_merged_spot_data_list()
+        merged_spot_data_dict = {}
+        for merged_spot_data in merged_spot_data_list:
+            spot_id = merged_spot_data["spot-id"]
+            merged_spot_data_dict[spot_id] = merged_spot_data
+        return merged_spot_data_dict

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -10,7 +10,7 @@ from disneyapp.data.db_handler import DBHandler
 
 @api_view(["GET", "POST"])
 def spot_list(request):
-    spots_json_org = SpotListDataConverter.get_merged_spot_data()
+    spots_json_org = SpotListDataConverter.get_merged_spot_data_list()
     filtered_spot_list = filter_unuse_spots(spots_json_org)
     spots_json_edited = edit_static_spots_data(filtered_spot_list)
     return Response(spots_json_edited)


### PR DESCRIPTION
### 概要
* `/search` で巡回経路を求める際に、スポットの営業時間（開始時間、終了時間）を考慮して探索を実施するように改修
  * スポットの営業開始時刻よりも前に到着した場合、または、スポットの営業終了時刻よりも後に到着した場合、2時間のペナルティコストを盛るようにした
  * これによって、営業時間内にスポットに到着する傾向が強くなった
* また、`/search` の返却結果に「該当スポットに営業時間外に到着したかどうか」を付与した
  * `violate-business-hours` 
  * API仕様書に記載済
    * https://github.com/Nakajima2nd/disney-app/wiki/API%E4%BB%95%E6%A7%98%E6%9B%B8#output