### PR TITLE
出発地または目的地に営業時間が存在するスポットが指定されるとエラーになるバグを修正

### DIFF
--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -204,15 +204,17 @@ class RandomTspSolver:
             # 営業開始より前に到着していないかチェック
             if "start-time" in self.spot_data_dict[spot.spot_id] and self.spot_data_dict[spot.spot_id]["start-time"] != "":
                 business_hours_start_time = self.spot_data_dict[spot.spot_id]["start-time"]  # 該当スポットの営業開始時刻
-                if hhmm_to_sec(spot.arrival_time) < hhmm_to_sec(business_hours_start_time):
-                    tour.spots[i].violate_business_hours = True
-                    tour.violate_business_hours = True
+                if spot.arrival_time != "":
+                    if hhmm_to_sec(spot.arrival_time) < hhmm_to_sec(business_hours_start_time):
+                        tour.spots[i].violate_business_hours = True
+                        tour.violate_business_hours = True
             # 営業終了より後に出発していないかチェック
             if "end-time" in self.spot_data_dict[spot.spot_id] and self.spot_data_dict[spot.spot_id]["end-time"] != "":
                 business_hours_end_time = self.spot_data_dict[spot.spot_id]["end-time"]  # 該当スポットの営業終了時刻
-                if hhmm_to_sec(business_hours_end_time) < hhmm_to_sec(spot.depart_time):
-                    tour.spots[i].violate_business_hours = True
-                    tour.violate_business_hours = True
+                if spot.depart_time != "":
+                    if hhmm_to_sec(business_hours_end_time) < hhmm_to_sec(spot.depart_time):
+                        tour.spots[i].violate_business_hours = True
+                        tour.violate_business_hours = True
             # 到着希望時刻を守っているかチェック
             for input_spot in travel_input.spots:
                 if input_spot.spot_id != spot.spot_id:


### PR DESCRIPTION
### 概要
* 掲題の通り
* 原因
  * スポットが営業時間を守っているのかのチェックまわりのバグ
  * 出発地には「到着時刻(arrival_time)」が存在せず、目的地には「出発時刻(depart_time)」が存在しないので、チェックをスキップする必要があるのだが、考慮が漏れていた
  * チェックをスキップする処理を入れてバグを解消した

### 検証
* すでにProduction環境に反映済
* スタートとゴールにレストランやアトラクションを指定して探索し、エラーが起きないことを確認済
https://disney-app-pi.vercel.app/