### PR TITLE
同じスポットが複数回指定された場合でも探索できるようにする

### DIFF
--- a/backend/disneyapp/algorithm/models.py
+++ b/backend/disneyapp/algorithm/models.py
@@ -250,18 +250,6 @@ class TravelInput:
 
         return travel_input_spot
 
-    @staticmethod
-    def __is_duplicate_spot(spots):
-        """
-        同じスポットが複数回指定されている場合Trueを返す。
-        """
-        spot_set = set()
-        for spot in spots:
-            if spot.spot_id in spot_set:
-                return True
-            spot_set.add(spot.spot_id)
-        return False
-
     def __init_spots(self, json_data):
         """
         spotsを初期化する。初期化に失敗した場合はFalseを返す。
@@ -280,9 +268,6 @@ class TravelInput:
             if not (travel_input_spot := self.__init_spot(spot_json)):
                 return False
             self.spots.append(travel_input_spot)
-        if TravelInput.__is_duplicate_spot(self.spots):
-            self.error_message = "同じスポットが複数回指定されています。"
-            return False
         return True
 
     def __init_optimize_spot_order(self, json_data):


### PR DESCRIPTION
### 概要
* `/search` の仕様変更
* これまでは同じスポットを複数して探索するとエラーにしていたが、経路を返すようにした
  * 同じスポットを連続して訪れる場合、経路長・所要時間は0になる

### 検証
* 同じスポットを複数回指定して探索に成功することを確認
<img width="459" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/133276084-6a5c997e-b9de-4d31-bec7-f7aec40bc684.PNG">
