### PR TITLE
コンフリクト発生時に発生した不具合を修正

### DIFF
--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -204,6 +204,14 @@ class RandomTspSolver:
             if i == len(tour.subroutes) - 1:
                 # ゴールの場合、出発時刻を到着時刻に合わせる
                 tour.spots[i + 1].depart_time = tour.spots[i + 1].arrival_time
+        # 待ち時間をセット
+        for i, spot in enumerate(tour.spots):
+            # 出発地と目的地については待ち時間を計算しない
+            if i == 0 or i == len(tour.spots) - 1:
+                tour.spots[i].wait_time = -1
+                continue
+            wait_time = self.__calc_wait_time(spot.spot_id, hhmm_to_sec(spot.arrival_time), travel_input.start_today)
+            tour.spots[i].wait_time = wait_time
         for i, spot in enumerate(tour.spots):
             if "start-time" in self.spot_data_dict[spot.spot_id] and self.spot_data_dict[spot.spot_id]["start-time"] != "":
                 # 営業開始より前に到着していないかチェック


### PR DESCRIPTION
### 概要
https://github.com/Nakajima2nd/disney-app/pull/102
これのコンフリクトを解消した際に、待ち時間が確定で-1になるバグを埋め込んでしまったので修正。

### 検証
Herokuにデプロイしてバグが解消することを確認。

before
![Screenshot_20210916-212002_Chrome](https://user-images.githubusercontent.com/33785163/133612023-0c6a11cd-a6ac-46d0-93e5-31dd2e0435e8.jpg)

after
![Screenshot_20210916-212520_Chrome](https://user-images.githubusercontent.com/33785163/133612033-137c53d8-d5ed-4b2f-b41d-d25fae6410e4.jpg)
