### PR TITLE
ショー名称中の時刻が正しくなるように修正

### DIFF
--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -189,6 +189,11 @@ class RandomTspSolver:
             tour_spot.spot_id = spot_id
             tour_spot.spot_name = self.spot_data_dict[spot_id]["name"]
             tour_spot.spot_short_name = self.spot_data_dict[spot_id]["short-name"]
+            # showの名称から開始時刻の情報が落ちているので、ここで付与する
+            if self.spot_data_dict[spot_id]["type"] == "show":
+                desired_arrival_time = self.__find_target_spot_from_travel_input(travel_input, spot_id).desired_arrival_time
+                tour_spot.spot_name = tour_spot.spot_name + "(" + sec_to_hhmm(desired_arrival_time) + ")"
+                tour_spot.spot_short_name = tour_spot.spot_short_name + "(" + sec_to_hhmm(desired_arrival_time) + ")"
             tour_spot.lat = self.spot_data_dict[spot_id]["lat"]
             tour_spot.lon = self.spot_data_dict[spot_id]["lon"]
             tour_spot.type = self.spot_data_dict[spot_id]["type"]

--- a/backend/disneyapp/data/spot_list_data_converter.py
+++ b/backend/disneyapp/data/spot_list_data_converter.py
@@ -43,10 +43,18 @@ class SpotListDataConverter:
     def get_merged_spot_data_dict():
         """
         静的データと動的データをマージし、spot-idをキーにしたdictにして返す。
+        ただし、showについては時刻指定の情報を削除する。
         """
         merged_spot_data_list = SpotListDataConverter.get_merged_spot_data_list()
         merged_spot_data_dict = {}
         for merged_spot_data in merged_spot_data_list:
             spot_id = merged_spot_data["spot-id"]
+            if spot_id in merged_spot_data_dict:
+                continue
+            # showの場合時刻指定の情報を削除する
+            if merged_spot_data["type"] == "show":
+                merged_spot_data["name"] = merged_spot_data["name"].split("(")[0]
+                merged_spot_data["short-name"] = merged_spot_data["short-name"].split("(")[0]
+                merged_spot_data["start-time"] = ""
             merged_spot_data_dict[spot_id] = merged_spot_data
         return merged_spot_data_dict


### PR DESCRIPTION
### 概要
* /search の結果表示画面において、ショーの名称が常に最終公演のものになってしまうバグを修正

### 検証
* 意図通り、`11:35` のショーである旨が出力されていることを確認
<img width="746" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/135719594-ff2e0b69-5c52-4390-bb14-3819b6a625d1.PNG">

