### PR TITLE
/search の結果が妥当であることを確認するテストを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,7 @@ front-sh:
 .PHONY: copy
 copy:
 	sudo docker cp disney-app_frontend_1:/code/node_modules ./frontend/
+
+.PHONY: test-backend
+test-backend:
+	docker-compose exec backend pytest

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ copy:
 
 .PHONY: test-backend
 test-backend:
-	docker-compose exec backend pytest
+	docker-compose exec backend pytest -s

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 ENV PYTHONUNBUFFERED 1
-ENV PYTHONPATH="/code/disneyapp/"
+ENV PYTHONPATH="/code/disneyapp/:/code/test/search"
 RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/

--- a/backend/disneyapp/algorithm/models.py
+++ b/backend/disneyapp/algorithm/models.py
@@ -56,7 +56,7 @@ class TourSpot:
         ret_dict["lat"] = self.lat
         ret_dict["lon"] = self.lon
         ret_dict["type"] = self.type
-        ret_dict["arrival_time"] = self.arrival_time
+        ret_dict["arrival-time"] = self.arrival_time
         ret_dict["specified-wait-time-result"] = self.specified_wait_time_result
         ret_dict["wait-time"] = self.wait_time
         ret_dict["play-time"] = self.play_time

--- a/backend/disneyapp/algorithm/models.py
+++ b/backend/disneyapp/algorithm/models.py
@@ -32,6 +32,7 @@ class Subroute:
 class TourSpot:
     def __init__(self):
         self.spot_id = -1
+        self.original_spot_order = -1
         self.spot_name = ""
         self.spot_short_name = ""
         self.lat = ""
@@ -51,6 +52,7 @@ class TourSpot:
     def to_dict(self):
         ret_dict = dict()
         ret_dict["spot-id"] = self.spot_id
+        ret_dict["original-spot-order"] = self.original_spot_order
         ret_dict["spot-name"] = self.spot_name
         ret_dict["short-spot-name"] = self.spot_short_name
         ret_dict["lat"] = self.lat
@@ -100,11 +102,8 @@ class Tour:
 class TravelInputSpot:
     def __init__(self):
         self.spot_id = -1
+        self.original_spot_order = -1  # Input中での当該スポットの番号
         self.desired_arrival_time = -1  # 00:00 からの経過秒数
-        # オリジナルの到着指定時刻。
-        # specified_wait_timeが指定された場合、巡回探索の際に内部的に到着希望時刻(desired_arrival_time)を早めるという処理を行っている。
-        # しかし、トレース時にオリジナルの到着希望時刻を参照する必要が出てきたため、こちらの変数で管理している。
-        self.desired_arrival_time_origin = -1
         self.stay_time = 0  # [分]
         self.specified_wait_time = 0
 
@@ -189,7 +188,7 @@ class TravelInput:
             return False
         return True
 
-    def __init_spot(self, spot_json):
+    def __init_spot(self, spot_json, original_spot_order):
         """
         TravelInputSpotオブジェクトを生成する。
         生成に失敗した場合はNoneを返す。
@@ -219,7 +218,6 @@ class TravelInput:
                 # hh:mm -> 秒数 への変換
                 hh_str, mm_str = spot_json["desired-arrival-time"].split(":")
                 travel_input_spot.desired_arrival_time = int(hh_str) * 3600 + int(mm_str) * 60
-                travel_input_spot.desired_arrival_time_origin = travel_input_spot.desired_arrival_time
             except:
                 self.error_message = "時間の形式が不正です。hh:mm形式で指定してください。"
                 return None
@@ -247,6 +245,7 @@ class TravelInput:
             except:
                 self.error_message = "specified-wait-timeには整数を指定してください。"
                 return None
+        travel_input_spot.original_spot_order = original_spot_order
 
         return travel_input_spot
 
@@ -262,7 +261,7 @@ class TravelInput:
             if spot_json.get("spot-id") == None:
                 self.error_message = str(i) + "番目のspotにspot-idが存在しません。"
                 return False
-            if not (travel_input_spot := self.__init_spot(spot_json)):
+            if not (travel_input_spot := self.__init_spot(spot_json, i)):
                 return False
             self.spots.append(travel_input_spot)
         return True
@@ -279,19 +278,15 @@ class TravelInput:
         return True
 
     def __init_start_today(self, json_data):
-        # note: フロントエンドの対応が入るまではバックエンドAPIの破壊的変更を入れない
-        if "start-today" in json_data:
-            self.start_today = json_data["start-today"]
+        if not json_data.get("start-today"):
+            self.error_message = "start-todayが存在しません"
+            return False
+        self.start_today = json_data["start-today"]
+        valid_start_today_list = ["true", "false"]
+        if self.start_today not in valid_start_today_list:
+            self.error_message = "start-todayはtrue/falseのいずれかで指定してください。"
+            return False
         return True
-        # if not json_data.get("start-today"):
-        #     self.error_message = "start-todayが存在しません"
-        #     return False
-        # self.start_today = json_data["start-today"]
-        # valid_start_today_list = ["true", "false"]
-        # if self.start_today not in valid_start_today_list:
-        #     self.error_message = "start-todayはtrue/falseのいずれかで指定してください。"
-        #     return False
-        # return True
 
     def init_by_json(self, json_data):
         if not self.__init_specified_time(json_data):

--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -48,7 +48,7 @@ def get_transit_time_min(distance, speed):
         return transit_time - mod
     else:
         # あまりが30秒以上であれば切り上げ
-        return transit_time - mod + 1
+        return transit_time - mod + 60
 
 
 class RandomTspSolver:

--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -208,6 +208,7 @@ class RandomTspSolver:
         for spot_obj in spot_order:
             tour_spot = TourSpot()
             tour_spot.spot_id = spot_obj.spot_id
+            tour_spot.original_spot_order = spot_obj.original_spot_order
             tour_spot.spot_name = self.spot_data_dict[spot_obj.spot_id]["name"]
             tour_spot.spot_short_name = self.spot_data_dict[spot_obj.spot_id]["short-name"]
             # showの名称から開始時刻の情報が落ちているので、ここで付与する

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ gunicorn
 django-heroku
 psycopg2-binary
 python-dotenv
+pytest
+requests

--- a/backend/test/search/input_generator.py
+++ b/backend/test/search/input_generator.py
@@ -1,0 +1,34 @@
+class InputGenerator:
+    @staticmethod
+    def generate_search_input(size):
+        """
+        /search の入力となるdictをランダムに（網羅的に）生成する。
+
+        Parameter:
+        ----------
+        size : int
+            返却するdictの個数。
+        """
+        return [{
+            "specified-time": "10:00",
+            "walk-speed": "fast",
+            "start-spot-id": 103,
+            "goal-spot-id": 103,
+            "optimize-spot-order": "true",
+            "start-today": "false",
+            "spots": [
+              {
+                "spot-id": 5
+              },
+              {
+                "spot-id": 108,
+                "desired-arrival-time": "12:40"
+              },
+              {
+                "spot-id": 21
+              },
+              {
+                "spot-id": 15
+              }
+            ]
+        }]

--- a/backend/test/search/input_generator.py
+++ b/backend/test/search/input_generator.py
@@ -44,7 +44,7 @@ class InputGenerator:
         spot_type = random.choice(spot_type_list)
         spot = random.choice(self.spot_list[spot_type])
         # 一応、スポットのタイプを付与する
-        spot["spot-type"] = spot_type
+        spot["type"] = spot_type
         return spot
 
     def __get_start_spot_id(self):
@@ -65,12 +65,47 @@ class InputGenerator:
         start_today_list = ["true", "false"]
         return random.choice(start_today_list)
 
+    def __set_desired_arrival_time(self, spot):
+        # 1/5の確率で到着時刻を設定する
+        set_arrival_time = [True, False, False, False, False]
+        if random.choice(set_arrival_time):
+            desired_arrival_time_list = ["10:00", "14:00", "16:00"]
+            desired_arrival_time = random.choice(desired_arrival_time_list)
+            spot["desired-arrival-time"] = desired_arrival_time
+
+    def __set_stay_time(self, spot):
+        # 1/5の確率で滞在時間を設定する
+        set_arrival_time = [True, False, False, False, False]
+        if random.choice(set_arrival_time):
+            stay_time_list = ["10", "30", "60"]
+            stay_time = random.choice(stay_time_list)
+            spot["stay-time"] = stay_time
+
+    def __set_specified_wait_time(self, spot):
+        # 1/5の確率で指定待ち時間を指定する
+        set_arrival_time = [True, False, False, False, False]
+        if random.choice(set_arrival_time):
+            specified_wait_time_list = ["10", "30", "60"]
+            specified_wait_time = random.choice(specified_wait_time_list)
+            spot["specified-wait-time"] = specified_wait_time
+
     def __get_spots(self):
         spot_num_candidate = [5, 10, 15]
         spot_num = random.choice(spot_num_candidate)
         spots = []
         for i in range(spot_num):
             spot = dict()
-            spot["spot-id"] = self.__get_random_spot()["spot-id"]
+            spot_info = self.__get_random_spot()
+            spot["spot-id"] = spot_info["spot-id"]
+            # 到着希望時刻
+            if spot_info["type"] in ["attraction", "restaurant", "place", "greeting", "show"]:
+                self.__set_desired_arrival_time(spot)
+            # 滞在時間
+            if spot_info["type"] in ["restaurant", "shop"]:
+                self.__set_stay_time(spot)
+            # 指定待ち時間
+            if spot_info["type"] == "show":
+                self.__set_specified_wait_time(spot)
             spots.append(spot)
         return spots
+

--- a/backend/test/search/input_generator.py
+++ b/backend/test/search/input_generator.py
@@ -1,6 +1,13 @@
+import random
+
+
 class InputGenerator:
-    @staticmethod
-    def generate_search_input(size):
+    random.seed(1)
+
+    def __init__(self, spot_list):
+        self.spot_list = spot_list
+
+    def generate_search_input(self, size):
         """
         /search の入力となるdictをランダムに（網羅的に）生成する。
 
@@ -9,26 +16,61 @@ class InputGenerator:
         size : int
             返却するdictの個数。
         """
-        return [{
-            "specified-time": "10:00",
-            "walk-speed": "fast",
-            "start-spot-id": 103,
-            "goal-spot-id": 103,
-            "optimize-spot-order": "true",
-            "start-today": "false",
-            "spots": [
-              {
-                "spot-id": 5
-              },
-              {
-                "spot-id": 108,
-                "desired-arrival-time": "12:40"
-              },
-              {
-                "spot-id": 21
-              },
-              {
-                "spot-id": 15
-              }
-            ]
-        }]
+        search_input_list = []
+        for count in range(size):
+            search_input = dict()
+            search_input["specified-time"] = InputGenerator.__get_specified_time()
+            search_input["walk-speed"] = InputGenerator.__get_walk_speed()
+            search_input["start-spot-id"] = self.__get_start_spot_id()
+            search_input["goal-spot-id"] = self.__get_goal_spot_id()
+            search_input["optimize-spot-order"] = InputGenerator.__get_optimize_spot_order()
+            search_input["start-today"] = InputGenerator.__get_start_today()
+            search_input["spots"] = self.__get_spots()
+            search_input_list.append(search_input)
+        return search_input_list
+
+    @staticmethod
+    def __get_specified_time():
+        specified_time_list = ["9:00", "12:00", "15:00", "18:00"]
+        return random.choice(specified_time_list)
+
+    @staticmethod
+    def __get_walk_speed():
+        walk_speed_list = ["slow", "normal", "fast"]
+        return random.choice(walk_speed_list)
+
+    def __get_random_spot(self):
+        spot_type_list = ["attraction", "restaurant", "show", "greeting", "place", "shop"]
+        spot_type = random.choice(spot_type_list)
+        spot = random.choice(self.spot_list[spot_type])
+        # 一応、スポットのタイプを付与する
+        spot["spot-type"] = spot_type
+        return spot
+
+    def __get_start_spot_id(self):
+        return 103
+        # return self.__get_random_spot()["spot-id"]
+
+    def __get_goal_spot_id(self):
+        return 103
+        # return self.__get_random_spot()["spot-id"]
+
+    @staticmethod
+    def __get_optimize_spot_order():
+        optimize_spot_order_list = ["true", "false"]
+        return random.choice(optimize_spot_order_list)
+
+    @staticmethod
+    def __get_start_today():
+        start_today_list = ["true", "false"]
+        return random.choice(start_today_list)
+
+    def __get_spots(self):
+        spot_num_candidate = [5, 10, 15]
+        spot_num = random.choice(spot_num_candidate)
+        spots = []
+        for i in range(spot_num):
+            spot = dict()
+            spot["spot-id"] = self.__get_random_spot()["spot-id"]
+            spots.append(spot)
+        return spots

--- a/backend/test/search/route_validator.py
+++ b/backend/test/search/route_validator.py
@@ -1,0 +1,19 @@
+class RouteValidator:
+    @staticmethod
+    def is_valid_route(search_input, route):
+        """
+        /search の入力であるdictと/searchの返却結果を受け取り、妥当なルートになっているかを検証する。
+
+        Parameters:
+        -----------
+        search_input : dict
+            /search の入力パラメタ。
+        route : dict
+            /search の出力ルート。
+
+        Returns:
+        --------
+        result : bool
+            妥当な経路になっている場合True, そうでなければFalse.
+        """
+        return True

--- a/backend/test/search/route_validator.py
+++ b/backend/test/search/route_validator.py
@@ -16,4 +16,31 @@ class RouteValidator:
         result : bool
             妥当な経路になっている場合True, そうでなければFalse.
         """
+        if not RouteValidator.__exist_expect_keys(route):
+            return False
+        return True
+
+    @staticmethod
+    def __exist_expect_keys(route):
+        """
+        ルートを構成するJsonに期待するキーが存在することを確認する。
+        """
+        expected_keys = ["start-time", "goal-time", "park-open-time", "park-close-time",
+                         "violate-desired-arrival-time", "violate-business-hours", "cost", "spots", "subroutes"]
+        for expected_key in expected_keys:
+            if expected_key not in route:
+                return False
+        spot_expected_keys = ["spot-id", "spot-name", "short-spot-name", "lat", "lon", "type", "arrival_time",
+                              "specified-wait-time-result", "wait-time", "play-time", "depart-time", "stay-time",
+                              "violate-business-hours", "violate-desired-arrival-time"]
+        for expected_key in spot_expected_keys:
+            for spot in route["spots"]:
+                if expected_key not in spot:
+                    return False
+        subroute_expected_keys = ["start-spot-id", "goal-spot-id", "start-time", "goal-time", "distance",
+                                  "transit-time", "coords", "surplus-wait-time"]
+        for expected_key in subroute_expected_keys:
+            for subroute in route["subroutes"]:
+                if expected_key not in subroute:
+                    return False
         return True

--- a/backend/test/search/route_validator.py
+++ b/backend/test/search/route_validator.py
@@ -1,6 +1,29 @@
+def sec_to_hhmm(sec):
+    """
+    秒からhh:mm形式の文字列に変換する。
+    """
+    hour = int(sec / 3600)
+    minute = int((sec - hour * 3600) / 60)
+    minute_str = str(minute)
+    if minute <= 9:
+        minute_str = "0" + minute_str
+    hhmm = str(hour) + ":" + minute_str
+    return hhmm
+
+
+def hhmm_to_sec(hh_mm_str):
+    """
+    hh:mm形式の文字列から秒に変換する。
+    """
+    hour, minute = hh_mm_str.split(":")
+    return int(hour) * 3600 + int(minute) * 60
+
+
 class RouteValidator:
-    @staticmethod
-    def is_valid_route(search_input, route):
+    def __init__(self):
+        self.error_message =""
+
+    def is_valid_route(self, search_input, route):
         """
         /search の入力であるdictと/searchの返却結果を受け取り、妥当なルートになっているかを検証する。
 
@@ -16,12 +39,15 @@ class RouteValidator:
         result : bool
             妥当な経路になっている場合True, そうでなければFalse.
         """
-        if not RouteValidator.__exist_expect_keys(route):
+        if not self.__exist_expect_keys(route):
+            return False
+        if not self.__check_basic_consistency_of_route(route):
+            return False
+        if not self.__check_time_consistency_of_route(route):
             return False
         return True
 
-    @staticmethod
-    def __exist_expect_keys(route):
+    def __exist_expect_keys(self, route):
         """
         ルートを構成するJsonに期待するキーが存在することを確認する。
         """
@@ -29,18 +55,93 @@ class RouteValidator:
                          "violate-desired-arrival-time", "violate-business-hours", "cost", "spots", "subroutes"]
         for expected_key in expected_keys:
             if expected_key not in route:
+                self.error_message = expected_key + "が存在しません。"
                 return False
-        spot_expected_keys = ["spot-id", "spot-name", "short-spot-name", "lat", "lon", "type", "arrival_time",
+        spot_expected_keys = ["spot-id", "spot-name", "short-spot-name", "lat", "lon", "type", "arrival-time",
                               "specified-wait-time-result", "wait-time", "play-time", "depart-time", "stay-time",
                               "violate-business-hours", "violate-desired-arrival-time"]
         for expected_key in spot_expected_keys:
             for spot in route["spots"]:
                 if expected_key not in spot:
+                    self.error_message = expected_key + "が存在しません。"
                     return False
         subroute_expected_keys = ["start-spot-id", "goal-spot-id", "start-time", "goal-time", "distance",
                                   "transit-time", "coords", "surplus-wait-time"]
         for expected_key in subroute_expected_keys:
             for subroute in route["subroutes"]:
                 if expected_key not in subroute:
+                    self.error_message = expected_key + " が存在しません。"
                     return False
+        return True
+
+    def __check_basic_consistency_of_route(self, route):
+        """
+        routeを構成する情報の一貫性がとれていることを確認する。
+        ただし、下記については別メソッドでチェックする。
+        ・所要時間
+        ・各種違反フラグ
+        """
+        spots = route["spots"]
+        subroutes = route["subroutes"]
+        if len(spots) == 0:
+            # 経由地の数が0なら特に何もチェックしない
+            return True
+        if len(spots) - 1 != len(subroutes):
+            self.error_message = "spotsの数とsubroutesの数が合っていません。"
+            return False
+        # 経路の出発時刻と到着時刻が、最初のスポットの出発時刻・最後のスポットの到着時刻と一致
+        if spots[0]["depart-time"] != route["start-time"]:
+            self.error_message = "最初のスポットの出発時刻と、経路の出発時刻が異なります。"
+            return False
+        if spots[-1]["arrival-time"] != route["goal-time"]:
+            self.error_message = "最後のスポットの到着時刻と、経路の到着時刻が異なります。"
+            return False
+        # 各spotとsubrouteについて、出発時刻・到着時刻・スポットIDが一致
+        for i, spot in enumerate(spots):
+            if i == len(spots) - 1:
+                continue
+            subroute = subroutes[i]
+            next_spot = spots[i + 1]
+            if subroute["start-spot-id"] != spot["spot-id"]:
+                self.error_message = "subrouteの出発地のspot-idと、出発スポットのspot-idが一致しません。"
+                return False
+            if subroute["goal-spot-id"] != next_spot["spot-id"]:
+                self.error_message = "subrouteの目的地のspot-idと、目的スポットのspot-idが一致しません。"
+                return False
+            if subroute["start-time"] != spot["depart-time"]:
+                self.error_message = "subrouteの出発時刻と、出発スポットの出発時刻が一致しません。"
+                return False
+            if subroute["goal-time"] != next_spot["arrival-time"]:
+                self.error_message = "subrouteの到着時刻と、目的スポットの到着時刻が一致しません。"
+                return False
+        return True
+
+    def __check_time_consistency_of_route(self, route):
+        """
+        ルートの所要時間に関する一貫性をチェックする。
+        """
+        spots = route["spots"]
+        subroutes = route["subroutes"]
+        spend_time = 0
+        for i, spot in enumerate(spots):
+            if i == len(spots) - 1:
+                continue
+            next_spot = spots[i + 1]
+            subroute = subroutes[i]
+            # 出発地スポットの出発時刻 + subroute所要時間 = 目的地スポットの到着時刻
+            subroute_transit_time = subroute["transit-time"] + subroute["surplus-wait-time"] * 60
+            if hhmm_to_sec(spot["depart-time"]) + subroute_transit_time != hhmm_to_sec(next_spot["arrival-time"]):
+                self.error_message = str(i) + "番目のsubrouteが次式を満たしません：出発地スポットの出発時刻 + subroute所要時間 = 目的地スポットの到着時刻"
+                return False
+            # 目的地スポットの到着時刻 + 目的地スポットのでのイベント消化 = 目的地スポットの出発時刻
+            goal_spot_time = max(next_spot["wait-time"], 0) * 60 + next_spot["specified-wait-time-result"] * 60 + \
+                             next_spot["play-time"] * 60 + next_spot["stay-time"] * 60
+            if hhmm_to_sec(next_spot["arrival-time"]) + goal_spot_time != hhmm_to_sec(next_spot["depart-time"]):
+                self.error_message = str(i) + "番目のsubrouteが次式を満たしません：目的地スポットの到着時刻 + 目的地スポットのでのイベント消化 = 目的地スポットの出発時刻"
+                return False
+            spend_time += (subroute_transit_time + goal_spot_time)
+        # 移動時間の合計 + スポットでのイベント消化時間の合計 = 所要時間
+        if spend_time != hhmm_to_sec(route["goal-time"]) - hhmm_to_sec(route["start-time"]):
+            self.error_message = "次式を満たしません：移動時間の合計 + スポットでのイベント消化時間の合計 = 所要時間"
+            return False
         return True

--- a/backend/test/search/route_validator.py
+++ b/backend/test/search/route_validator.py
@@ -39,14 +39,14 @@ class RouteValidator:
         result : bool
             妥当な経路になっている場合True, そうでなければFalse.
         """
-        # if not self.__exist_expect_keys(route):
-        #     return False
-        # if not self.__check_basic_consistency_of_route(route):
-        #     return False
-        # if not self.__check_time_consistency_of_route(route):
-        #     return False
-        # if not self.__check_violate_flag(route):
-        #     return False
+        if not self.__exist_expect_keys(route):
+            return False
+        if not self.__check_basic_consistency_of_route(route):
+            return False
+        if not self.__check_time_consistency_of_route(route):
+            return False
+        if not self.__check_violate_flag(route):
+            return False
         if not self.__is_user_expected_route(search_input, route):
             return False
         return True

--- a/backend/test/search/route_validator.py
+++ b/backend/test/search/route_validator.py
@@ -39,11 +39,15 @@ class RouteValidator:
         result : bool
             妥当な経路になっている場合True, そうでなければFalse.
         """
-        if not self.__exist_expect_keys(route):
-            return False
-        if not self.__check_basic_consistency_of_route(route):
-            return False
-        if not self.__check_time_consistency_of_route(route):
+        # if not self.__exist_expect_keys(route):
+        #     return False
+        # if not self.__check_basic_consistency_of_route(route):
+        #     return False
+        # if not self.__check_time_consistency_of_route(route):
+        #     return False
+        # if not self.__check_violate_flag(route):
+        #     return False
+        if not self.__is_user_expected_route(search_input, route):
             return False
         return True
 
@@ -144,4 +148,83 @@ class RouteValidator:
         if spend_time != hhmm_to_sec(route["goal-time"]) - hhmm_to_sec(route["start-time"]):
             self.error_message = "次式を満たしません：移動時間の合計 + スポットでのイベント消化時間の合計 = 所要時間"
             return False
+        return True
+
+    def __check_violate_flag(self, route):
+        """
+        各種違反フラグが正しいか確認する。
+        """
+        return True
+
+    def __is_user_expected_route(self, input, route):
+        """
+        ユーザの入力情報と経路が一致しているか確認する。
+        """
+        # 出発時刻が意図したものになっている
+        if input["specified-time"] != route["start-time"]:
+            self.error_message = "出発時刻が入力で指定したものと異なります。"
+            return False
+        # 出発地点、到着地点が意図したものになっている
+        if input["start-spot-id"] != route["spots"][0]["spot-id"]:
+            self.error_message = "出発地点が入力で指定したものと異なります。"
+            return False
+        if input["goal-spot-id"] != route["spots"][-1]["spot-id"]:
+            self.error_message = "目的地店が入力で指定したものと異なります。"
+            return False
+        # 経由地をすべてめぐる経路が出ている
+        input_spot_id_set = set([spot["spot-id"] for spot in input["spots"]])
+        route_spot_id_set = set([spot["spot-id"] for spot in route["spots"]][1:-1])  # spotsの最初と最後は除く
+        if input_spot_id_set != route_spot_id_set:
+            self.error_message = "入力で指定したスポットの集合と、実際にめぐっているスポットの集合が異なります。"
+            return False
+        # 到着希望時刻が守られている
+        if not self.__meet_desired_arrival_times(input, route):
+            return False
+        # 滞在時間指定が守られている
+        if not self.__meet_stay_times(input, route):
+            return False
+        # 希望待ち時間が守られている
+        if not self.__meet_specified_wait_times(input, route):
+            return False
+        # optimize-spot-orderがfalseの場合、入力した地点順序で巡回している
+        return True
+
+    def __meet_desired_arrival_times(self, input, route):
+        """
+        到着希望時刻がすべて守られている場合Trueを返す。
+        同じスポットが複数指定され、それぞれ別々の到着希望時刻指定がなされている場合も考慮する。
+        """
+        # 各スポットIDから、そのスポットIDに指定されている指定時刻一覧を引けるdictをつくる
+        input_spotid_to_spot_dict = {}  # spot_id -> [spot]
+        for spot in input["spots"]:
+            if "desired-arrival-time" not in spot:
+                continue
+            spot_id = spot["spot-id"]
+            if spot_id in input_spotid_to_spot_dict:
+                input_spotid_to_spot_dict[spot_id].append(spot["desired-arrival-time"])
+            else:
+                input_spotid_to_spot_dict[spot_id] = [spot["desired-arrival-time"]]
+        for spot_id in input_spotid_to_spot_dict:
+            desired_arrival_time_list = input_spotid_to_spot_dict[spot_id]
+            for desired_arrival_time in desired_arrival_time_list:
+                target_spot_find_flag = False
+                for spot in route["spots"]:
+                    if spot["spot-id"] == spot_id and spot["arrival-time"] == desired_arrival_time:
+                        target_spot_find_flag = True
+                        del spot
+                if not target_spot_find_flag:
+                    self.error_message = "スポットID=" + str(spot_id) + ", 到着希望時刻=" + str(desired_arrival_time) + " が満たされていません。"
+                    return False
+        return True
+
+    def __meet_stay_times(self, input, route):
+        """
+        滞在時間がすべて守られている場合Trueを返す。
+        """
+        return True
+
+    def __meet_specified_wait_times(self, input, route):
+        """
+        指定待ち時間がすべて満たされている場合Trueを返す。
+        """
         return True

--- a/backend/test/search/test_exhaustive.py
+++ b/backend/test/search/test_exhaustive.py
@@ -8,8 +8,13 @@ import json
 def test_exhaustive():
     input_dict_list = InputGenerator.generate_search_input(1)
     route_validator = RouteValidator()
+    url = "http://localhost:8001/search"
+    try:
+        # 一度バックエンドサーバをたたいておくとのちの挙動がスムーズになる
+        requests.get("http://localhost:8001/spot/list", timeout=1.0)
+    except:
+        pass
     for input_dict in input_dict_list:
-        url = "http://localhost:8001/search"
         response = requests.post(url, json=input_dict)
         assert response.status_code == 200
         route_dict = json.loads(response.text)

--- a/backend/test/search/test_exhaustive.py
+++ b/backend/test/search/test_exhaustive.py
@@ -6,7 +6,7 @@ import json
 
 
 def test_exhaustive():
-    REQUEST_NUM = 100
+    REQUEST_NUM = 200
     route_validator = RouteValidator()
     url = "http://localhost:8001/search"
     try:

--- a/backend/test/search/test_exhaustive.py
+++ b/backend/test/search/test_exhaustive.py
@@ -7,11 +7,11 @@ import json
 
 def test_exhaustive():
     input_dict_list = InputGenerator.generate_search_input(1)
+    route_validator = RouteValidator()
     for input_dict in input_dict_list:
         url = "http://localhost:8001/search"
         response = requests.post(url, json=input_dict)
         assert response.status_code == 200
         route_dict = json.loads(response.text)
-        assert RouteValidator.is_valid_route(input_dict, route_dict)
-
-
+        result = route_validator.is_valid_route(input_dict, route_dict)
+        assert result, route_validator.error_message

--- a/backend/test/search/test_exhaustive.py
+++ b/backend/test/search/test_exhaustive.py
@@ -11,6 +11,7 @@ def test_exhaustive():
         url = "http://localhost:8001/search"
         response = requests.post(url, json=input_dict)
         assert response.status_code == 200
-        assert RouteValidator.is_valid_route(input_dict, json.loads(response.text))
+        route_dict = json.loads(response.text)
+        assert RouteValidator.is_valid_route(input_dict, route_dict)
 
 

--- a/backend/test/search/test_exhaustive.py
+++ b/backend/test/search/test_exhaustive.py
@@ -1,0 +1,16 @@
+from input_generator import InputGenerator
+from route_validator import RouteValidator
+
+import requests
+import json
+
+
+def test_exhaustive():
+    input_dict_list = InputGenerator.generate_search_input(1)
+    for input_dict in input_dict_list:
+        url = "http://localhost:8001/search"
+        response = requests.post(url, json=input_dict)
+        assert response.status_code == 200
+        assert RouteValidator.is_valid_route(input_dict, json.loads(response.text))
+
+

--- a/backend/test/search/test_exhaustive.py
+++ b/backend/test/search/test_exhaustive.py
@@ -6,17 +6,20 @@ import json
 
 
 def test_exhaustive():
-    input_dict_list = InputGenerator.generate_search_input(1)
+    REQUEST_NUM = 100
     route_validator = RouteValidator()
     url = "http://localhost:8001/search"
     try:
-        # 一度バックエンドサーバをたたいておくとのちの挙動がスムーズになる
         requests.get("http://localhost:8001/spot/list", timeout=1.0)
     except:
         pass
-    for input_dict in input_dict_list:
+    spot_list_dict = json.loads(requests.get("http://localhost:8001/spot/list").text)
+    input_generator = InputGenerator(spot_list_dict)
+    input_dict_list = input_generator.generate_search_input(REQUEST_NUM)
+    for i, input_dict in enumerate(input_dict_list):
+        print(str(i) + "/" + str(len(input_dict_list)) + " completed...")
         response = requests.post(url, json=input_dict)
         assert response.status_code == 200
         route_dict = json.loads(response.text)
         result = route_validator.is_valid_route(input_dict, route_dict)
-        assert result, route_validator.error_message
+        assert result, route_validator.error_message + " " + json.dumps(input_dict)


### PR DESCRIPTION
### 概要
* /search のテストを追加
  * また、テストを追加したことで明らかになったいくつかの不具合を修正
* コンテナを起動した状態で `make test-backend`
* コメントをけっこうしっかり目に書いたので、テストケースについて確認する場合はコメントを参照

### テスト残タスク
* テストケースを増やす
  * 現状、1つのテストケース(httpリクエスト)しか用意していないので、もっとたくさん整備したい
* 到着希望時刻のテスト
  * 現状、「これが満たされていなければ明らかに不正な経路」というパターンしかチェックしていない
  * 到着希望時刻は、入力パラメタ次第では守られないのが正であることもあるので、今回はチェックしていない
  * ただ、到着希望時刻まわりはバグりやすいので、そのうち何らかの形でテスト保護したい