### PR TITLE
DBからデータ取得時にソートしないようにする

### DIFF
--- a/backend/disneyapp/data/db_handler.py
+++ b/backend/disneyapp/data/db_handler.py
@@ -22,7 +22,7 @@ class DBHandler:
         """
         with psycopg2.connect(self.database_url, sslmode='require') as conn:
             with conn.cursor(cursor_factory=DictCursor) as cur:
-                cur.execute("SELECT data FROM " + table_name + " ORDER BY datetime DESC")
+                cur.execute("SELECT data FROM " + table_name + " ORDER BY datetime DESC limit 1")
                 latest_dynamic_record = cur.fetchone()
                 return json.loads(latest_dynamic_record["data"])
 


### PR DESCRIPTION
### 概要
* localhost でbackend API（特に `/spot/list`）をたたいた際に時間がかかる問題の修正
* 原因
  * DBをたたく際に、最新のデータを取得するために「すべてのデータを取得→ソート→1件だけ取得」としていた
  * ソート部分にめっちゃ時間がかかっていたぽい
* 対応
  * SQLクエリに `limit 1` をつけてソートしなくていいようにした

### 結果
かなり早くなった。
```
/spot/list 改修前パフォーマンス
real    1m11.273s
user    0m0.012s
sys     0m0.000s

/spot/list 改修後パフォーマンス
real    0m2.028s
user    0m0.006s
sys     0m0.000s
```

### 学び
データは必要なぶんだけとってくるようにする。