### PR TITLE
タブの挙動を修正、他

### DIFF
--- a/frontend/components/SpotList.jsx
+++ b/frontend/components/SpotList.jsx
@@ -23,9 +23,9 @@ const CustomListItem = styled(ListItem)`
   display: flex;
   border-bottom: 1px solid lightgray;
   justify-content: space-between;
-  margin: 0 8px;
-  padding: ${(props) => props.checkbox ? '0 8px 0 40px' : '0 8px'};
-  width: calc(100% - 16px);
+  margin: 0;
+  padding: ${(props) => props.checkbox ? '0 16px 0 48px' : '0 16px'};
+  width: 100%;
   height: 75px;
 `
 

--- a/frontend/components/SpotListDialog.jsx
+++ b/frontend/components/SpotListDialog.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Button, Dialog, DialogActions, DialogContent, Fab, IconButton } from '@material-ui/core'
+import { Box, Button, Dialog, DialogActions, DialogContent, Fab, IconButton } from '@material-ui/core'
 import { Add, Close } from '@material-ui/icons'
 import { append, assoc, last, pipe, update } from 'ramda'
 import { ConditionInput } from './ConditionInput'
@@ -14,6 +14,17 @@ const CloseButton = styled(IconButton)`
 `
 
 const SpotDialogContent = styled(DialogContent)`
+  position: relative;
+  overflow: hidden;
+`
+
+const ContentWrap = styled(Box)`
+  overflow-y: auto;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: ${props => props.current ? 0 : '100%'};
 `
 
 const CustomFab = styled(Fab)`
@@ -168,7 +179,10 @@ export const SpotListDialog = ({ spotList, editing, selected, open, spots, setEd
         <Close />
       </CloseButton>
       <SpotDialogContent>
-        {editing.step === 0 &&
+        <ContentWrap
+          current={editing.step === 0}
+          opacity={editing.step === 0 ? 1 : 0}
+        >
           <SpotSelect
             handleKeyword={handleKeyword}
             handleTab={handleTab}
@@ -179,8 +193,11 @@ export const SpotListDialog = ({ spotList, editing, selected, open, spots, setEd
             handleCheckbox={handleCheckbox}
             selected={selected}
           />
-        }
-        {editing.step === 1 &&
+        </ContentWrap>
+        <ContentWrap
+          current={editing.step === 1}
+          opacity={editing.step === 1 ? 1 : 0}
+        >
           <ConditionInput
             handleDesiredArrivalTime={handleDesiredArrivalTime}
             handleStayTime={handleStayTime}
@@ -188,7 +205,7 @@ export const SpotListDialog = ({ spotList, editing, selected, open, spots, setEd
             editing={editing}
             handleSwitches={handleSwitches}
           />
-        }
+        </ContentWrap>
       </SpotDialogContent>
       {editing.step === 1 &&
         <DialogActions>

--- a/frontend/components/SpotSelect.jsx
+++ b/frontend/components/SpotSelect.jsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components'
-import { Tabs, Tab, TextField, InputAdornment } from '@material-ui/core'
+import { Box, Tabs, Tab, TextField, InputAdornment } from '@material-ui/core'
 import { Restaurant, SportsTennis, AccessibilityNew, ShoppingCart, Search, Mood, Flag } from '@material-ui/icons'
 import { SpotList } from './SpotList'
+import { TabPanel } from '../styles/parts'
 
 const KeywordInput = styled(TextField)`
   padding: 0 16px;
@@ -12,6 +13,9 @@ const SpotTabs = styled(Tabs)`
 `
 
 const SpotTab = styled(Tab)`
+`
+
+const TabPanels = styled(Box)`
 `
 
 export const SpotSelect = ({ handleKeyword, handleTab, spotList, editing, handleClickSpot, checked, handleCheckbox, selected }) => {
@@ -36,20 +40,30 @@ export const SpotSelect = ({ handleKeyword, handleTab, spotList, editing, handle
       textColor="primary"
       scrollButtons="on"
     >
-      <SpotTab icon={<SportsTennis />} label="アトラクション" value="attraction"/>
-      <SpotTab icon={<Restaurant />} label="レストラン" value="restaurant"/>
-      <SpotTab icon={<ShoppingCart />} label="ショップ" value="shop"/>
-      <SpotTab icon={<Flag />} label="スポット" value="place"/>
-      <SpotTab icon={<AccessibilityNew />} label="ショー" value="show"/>
-      <SpotTab icon={<Mood />} label="グリーティング" value="greeting"/>
+      <SpotTab icon={<SportsTennis />} label="アトラクション" value="attraction" />
+      <SpotTab icon={<Restaurant />} label="レストラン" value="restaurant" />
+      <SpotTab icon={<ShoppingCart />} label="ショップ" value="shop" />
+      <SpotTab icon={<Flag />} label="スポット" value="place" />
+      <SpotTab icon={<AccessibilityNew />} label="ショー" value="show" />
+      <SpotTab icon={<Mood />} label="グリーティング" value="greeting" />
     </SpotTabs>
-    <SpotList
-      list={spotList[editing.tab]}
-      editing={editing}
-      handleClickSpot={handleClickSpot}
-      checked={checked}
-      handleCheckbox={handleCheckbox}
-      selected={selected}
-    />
+    <TabPanels>
+      {Object.entries(spotList).map(([key, value], index) => (
+        <TabPanel
+          key={index}
+          value={editing.tab}
+          index={key}
+        >
+          <SpotList
+            list={value}
+            editing={editing}
+            handleClickSpot={handleClickSpot}
+            checked={checked}
+            handleCheckbox={handleCheckbox}
+            selected={selected}
+          />
+        </TabPanel>
+      ))}
+    </TabPanels>
   </>)
 }

--- a/frontend/components/charts/WaitTimeChart.js
+++ b/frontend/components/charts/WaitTimeChart.js
@@ -7,11 +7,20 @@ const Chart = dynamic(() => import('react-apexcharts'), { ssr: false })
 const Wrap = styled(Box)`
   background-color: #E1F8FF;
   height: 301px;
+  position: relative;
 `
 
 const Title = styled(Typography)`
   text-align: center;
   padding-top: 16px;
+`
+
+const CustomFade = styled(Fade)`
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 0);
+  width: 100%;
 `
 
 const Info = styled(Box)`
@@ -112,13 +121,13 @@ export const WaitTimeChart = ({ timespanMeanWaitTime, waitTime }) => {
         width="100%"
         height={240}
       />
-      <Fade in={true} timeout={1000}>
-        <Info visible={diffWaitTime}>
+      <CustomFade in={true} timeout={1000}>
+        <Info visible={diffWaitTime !== null}>
           <Typography>ただいま、普段より</Typography>
           <DiffWaitTime>{Math.abs(diffWaitTime)}分</DiffWaitTime>
           <Typography>{diffWaitTime < 0 ? 'すいています' : 'こんでいます'}</Typography>
         </Info>
-      </Fade>
+      </CustomFade>
     </Wrap>
   )
 }

--- a/frontend/styles/parts.js
+++ b/frontend/styles/parts.js
@@ -1,6 +1,17 @@
 import styled from 'styled-components'
 import { Button } from '@material-ui/core'
 
+export const TabPanel = ({ children, value, index }) => {
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+    >
+      {children}
+    </div>
+  )
+}
+
 export const Mickey = styled.span`
   width: 0.9rem;
   height: 0.9rem;


### PR DESCRIPTION
#### 概要
* タブを切り替えたときに、一瞬切り替え前のスポットの画像が表示されていた問題を修正
* スポット一覧でスポットを押す→スポット詳細でもどるを押す→戻ったときスクロール位置が保持されていて嬉しい
* スポット詳細のグラフで、グラフの描画前に`ただいま、普段より〜`の文言がグラフと重なる問題を修正