### PR TITLE
/searchのみキャッシュを使い、/spot/listでは毎回DBからデータを取得する

### DIFF
--- a/backend/disneyapp/algorithm/tsp_solver.py
+++ b/backend/disneyapp/algorithm/tsp_solver.py
@@ -123,7 +123,7 @@ class RandomTspSolver:
         """
         巡回経路探索で用いるSpotデータを初期化する。
         """
-        merged_spot_data_dict = SpotListDataConverter.get_merged_spot_data_dict()
+        merged_spot_data_dict = SpotListDataConverter.get_merged_spot_data_dict(use_cache=True)
 
         for spot_id in merged_spot_data_dict:
             # play-time が存在しない場合は0埋めする

--- a/backend/disneyapp/data/data_manager.py
+++ b/backend/disneyapp/data/data_manager.py
@@ -11,10 +11,18 @@ class DynamicDataManager:
     prev_fetch_data = {}
 
     @classmethod
-    def fetch_latest_data(cls):
+    def fetch_latest_data(cls, use_cache=False):
+        """
+        最新のデータをDBから取得する。
+
+        Parameter:
+        ----------
+        use_cache : bool
+            キャッシュデータを使う場合Trueを指定する。
+        """
         current_time = int(time.time())
         # 前回データ取得時から5分以内であれば前回取得データを使いまわす
-        if current_time - cls.prev_fetch_time < 300:
+        if (current_time - cls.prev_fetch_time < 300) and use_cache:
             return cls.prev_fetch_data
         cls.prev_fetch_time = current_time
         db_handler = DBHandler()

--- a/backend/disneyapp/data/park_data_accessor.py
+++ b/backend/disneyapp/data/park_data_accessor.py
@@ -11,7 +11,7 @@ class ParkDataAccessor:
         """
         最新の日時の開園時間、閉園時間を返す。
         """
-        latest_data = DynamicDataManager.fetch_latest_data()
+        latest_data = DynamicDataManager.fetch_latest_data(use_cache=True)
         opening_hours_dict = latest_data["開園時間"]
         opening_hours_obj = OpeningHours(opening_hours_dict)
         return opening_hours_obj

--- a/backend/disneyapp/data/spot_list_data_converter.py
+++ b/backend/disneyapp/data/spot_list_data_converter.py
@@ -20,15 +20,20 @@ class SpotListDataConverter:
             return PlaceSpotInfo()
 
     @staticmethod
-    def get_merged_spot_data_list():
+    def get_merged_spot_data_list(use_cache=False):
         """
         静的データと動的データを、スポット名称をキーにマージして返す。
+
+        Parameter:
+        ----------
+        use_cache : bool
+            キャッシュデータを使う場合true。
 
         Returns: array-like
             スポット情報のリスト。
         """
         spot_static_data_list = StaticDataManager.get_spots()
-        spot_dynamic_data = DynamicDataManager.fetch_latest_data()
+        spot_dynamic_data = DynamicDataManager.fetch_latest_data(use_cache)
         merged_spot_data_list = []
         for static_spot_data in spot_static_data_list:
             merged_spot_data = SpotListDataConverter.select_spot_info_class(static_spot_data)
@@ -40,12 +45,17 @@ class SpotListDataConverter:
         return merged_spot_data_list
 
     @staticmethod
-    def get_merged_spot_data_dict():
+    def get_merged_spot_data_dict(use_cache=False):
         """
         静的データと動的データをマージし、spot-idをキーにしたdictにして返す。
         ただし、showについては時刻指定の情報を削除する。
+
+        Parameter:
+        ----------
+        use_cache : bool
+            キャッシュデータを使う場合true。
         """
-        merged_spot_data_list = SpotListDataConverter.get_merged_spot_data_list()
+        merged_spot_data_list = SpotListDataConverter.get_merged_spot_data_list(use_cache)
         merged_spot_data_dict = {}
         for merged_spot_data in merged_spot_data_list:
             spot_id = merged_spot_data["spot-id"]


### PR DESCRIPTION
### 概要
* これの対応：https://coins-dawn.slack.com/archives/C01UWS1LH4P/p1636851782001400
* これまでは、前回のDBアクセスから5分以内であれば、DBにアクセスせず内部のキャッシュを使いまわしていた
  * PF向上のため
* 一方で、先日インした際にそれでは待ち時間情報の更新が間に合わないことがわかった
* PFとの兼ね合いを考え下記のような挙動とした
  * `/spot/list` を実行 → 毎回DBにアクセス
  * `/search` を実行 → これまでと同じ。5分以内であればキャッシュを使う
* この対応により、アプリの起動がこころもちもっさりするようになった（とはいえ、個人的にはそこまで気にならないくらい）