### PR TITLE
探索結果画面の待ち時間の表示を変更

### DIFF
--- a/frontend/components/SpotList.jsx
+++ b/frontend/components/SpotList.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { Avatar, Box, Typography, List, ListItem, ListItemSecondaryAction, Checkbox } from '@material-ui/core'
 import { Fragment } from 'react'
 import { groupBy } from 'ramda'
+import { hasWaitTime } from '../utils'
 
 const Wrap = styled(Box)`
   margin-top: 24px;
@@ -84,8 +85,6 @@ export const SpotList = ({ list, editing, handleClickSpot, checked, handleCheckb
     return str.replace(/\(((0?[0-9]|1[0-9])|2[0-3]):[0-5][0-9]\)/, '')
   }
   
-  const hasWaitTime = (type) => ["attraction", "restaurant", "greeting"].includes(type)
-
   return (<>
     {Object.entries(groupedSpots).map(([area, spots], index) =>
       <Wrap key={index}>

--- a/frontend/pages/search/index.js
+++ b/frontend/pages/search/index.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import { Loading } from '../../components/Loading'
 import { useGetSearchResult } from '../../hooks'
 import { ArrowRightAlt, DirectionsWalk, Room } from '@material-ui/icons'
+import { hasWaitTime } from '../../utils'
 
 const Wrap = styled(Box)`
   margin: auto;
@@ -65,6 +66,14 @@ const EnableAvatar = styled(Avatar)`
   width: 4rem;
   height: 4rem;
   font-size: 1.6rem;
+`
+
+const DisableAvatar = styled(Avatar)`
+  color: white;
+  background-color: lightgray;
+  width: 4rem;
+  height: 4rem;
+  font-size: 1.2rem;
 `
 
 const WtaiTimeText = styled(Typography)`
@@ -148,9 +157,17 @@ const Search = ({ query }) => {
             <Text color="textSecondary">{index < searchResult.subroutes.length && searchResult.subroutes[index].startTime + '発'}</Text>
           </Timetable>
           <SpotText>{spot.shortSpotName}</SpotText>
-          <WaitTime visibility={index > 0 && index < searchResult.spots.length - 1 ? 'visible' : 'hidden'}>
-            <EnableAvatar>{spot.waitTime}分</EnableAvatar>
-            <WtaiTimeText color="textSecondary">待ち</WtaiTimeText>
+          <WaitTime visibility={index > 0 && index < searchResult.spots.length - 1 && hasWaitTime(spot.type) ? 'visible' : 'hidden'}>
+            {spot.violateBusinessHour && <>
+              <DisableAvatar>時間外</DisableAvatar>
+            </>}
+            {!spot.violateBusinessHour && spot.waitTime === -1 && <>
+              <DisableAvatar>休止中</DisableAvatar>
+            </>}
+            {!spot.violateBusinessHour && spot.waitTime !== -1 && <>
+              <EnableAvatar>{spot.waitTime}分</EnableAvatar>
+              <WtaiTimeText color="textSecondary">待ち</WtaiTimeText>
+            </>}
           </WaitTime>
         </Spot>
         {index < searchResult.subroutes.length &&

--- a/frontend/utils.js
+++ b/frontend/utils.js
@@ -58,3 +58,5 @@ export const parseDateTime = (string) => {
     return now
   }
 }
+
+export const hasWaitTime = type => ["attraction", "restaurant", "greeting"].includes(type)


### PR DESCRIPTION
#### 概要
* /search の返却結果においてショップ、スポット、ショーの待ち時間を出力しない
* 待ち時間が-1にならないようにする