### PR TITLE
チケット予約状況ページに必要なAPIを整備（途中）

### DIFF
--- a/backend/disneyapp/data/data_manager.py
+++ b/backend/disneyapp/data/data_manager.py
@@ -26,7 +26,7 @@ class DynamicDataManager:
             return cls.prev_fetch_data
         cls.prev_fetch_time = current_time
         db_handler = DBHandler()
-        cls.prev_fetch_data = db_handler.fetch_latest_dynamic_data(table_name="sea_dynamic_data")
+        cls.prev_fetch_data = db_handler.fetch_sea_dynamic_data()
         return cls.prev_fetch_data
 
 

--- a/backend/disneyapp/data/db_handler.py
+++ b/backend/disneyapp/data/db_handler.py
@@ -16,13 +16,29 @@ class DBHandler:
         if not self.database_url:
             self.database_url = str(os.environ['DATABASE_URL'])
 
-    def fetch_latest_dynamic_data(self, table_name):
+    def fetch_sea_dynamic_data(self):
         """
-        最新の動的情報をDBから取得し、Jsonオブジェクトに変換して返す。
+        最新のTDSの動的情報をDBから取得し、Jsonオブジェクトに変換して返す。
         """
+        TABLE_NAME = "sea_dynamic_data"
         with psycopg2.connect(self.database_url, sslmode='require') as conn:
             with conn.cursor(cursor_factory=DictCursor) as cur:
-                cur.execute("SELECT data FROM " + table_name + " ORDER BY datetime DESC limit 1")
+                cur.execute("SELECT data FROM " + TABLE_NAME + " ORDER BY datetime DESC limit 1")
                 latest_dynamic_record = cur.fetchone()
                 return json.loads(latest_dynamic_record["data"])
+
+    def fetch_ticket_reservation_info(self, from_time, upto_time):
+        """
+        指定した時刻範囲のチケット予約情報をDBから取得する。
+        from_time, to_time : YYYY-MM-DD型式の文字列
+        """
+        TABLE_NAME = "dticket_status"
+        with psycopg2.connect(self.database_url, sslmode='require') as conn:
+            with conn.cursor(cursor_factory=DictCursor) as cur:
+                cur.execute(f"SELECT * FROM {TABLE_NAME} "
+                            f"WHERE target_date >= '{from_time}' and target_date <= '{upto_time}'"
+                            f"ORDER BY target_date")
+                result = cur.fetchall()
+                return result
+
 

--- a/backend/disneyapp/data/models.py
+++ b/backend/disneyapp/data/models.py
@@ -374,3 +374,45 @@ class OpeningHours:
     def __init__(self, opening_hours_dict):
         self.open_time = opening_hours_dict["open-time"]
         self.close_time = opening_hours_dict["close-time"]
+
+
+class WeatherInfo:
+    """
+    天気情報のクラス。
+    """
+    def __init__(self):
+        self.chance_of_rain = 0   # 降水確率
+        self.high_temperature = 0 # 最高気温
+        self.low_temperature = 0  # 最低気温
+        self.wind_speed = 0       # 風速
+
+    def to_dict(self):
+        return {
+            "chance_of_rain" : self.chance_of_rain,
+            "high-temperature": self.high_temperature,
+            "low-temperature": self.low_temperature,
+            "wind-speed": self.wind_speed
+        }
+
+
+class TicketReservationInfo:
+    """
+    チケット予約情報のクラス。
+    """
+    def __init__(self):
+        self.date_str = ""
+        self.one_day_pass_sea = False
+        self.one_day_pass_land = False
+        self.last_update_str = ""
+        self.weather_info = WeatherInfo()
+
+    def to_dict(self):
+        return {
+            "date_str" : self.date_str,
+            "last_update": self.last_update_str,
+            "oneday-pass": {
+                "sea": self.one_day_pass_sea,
+                "land": self.one_day_pass_land
+            },
+            "weather" : self.weather_info.to_dict()
+        }

--- a/backend/disneyapp/data/ticket_reservation_accesor.py
+++ b/backend/disneyapp/data/ticket_reservation_accesor.py
@@ -1,0 +1,43 @@
+from disneyapp.data.db_handler import DBHandler
+from disneyapp.data.models import TicketReservationInfo
+import datetime
+
+
+class TicketReservationAccessor:
+    @staticmethod
+    def fetch_ticket_status_list():
+        """
+        現在時刻から1か月分のチケット販売情報およい付随情報を返す。
+        """
+        ticket_status_list = []
+        num_of_target_date = 30 # 何日分の情報を返すか
+        db_handler = DBHandler()
+        dt_now = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=9)))
+        dt_upto_time = dt_now + datetime.timedelta(days=num_of_target_date)
+        db_result_list = db_handler.fetch_ticket_reservation_info(dt_now.strftime("%Y-%m-%d"),
+                                                                  dt_upto_time.strftime("%Y-%m-%d"))
+        ticket_status_sea_dict = {}
+        ticket_status_land_dict = {}
+        last_update_time_dict = {}
+        for db_result in db_result_list:
+            datetime_str = db_result[0]
+            type = db_result[1]
+            can_reserve = db_result[2]
+            last_update_time_dict[datetime_str] = db_result[3]
+            if type == "sea":
+                ticket_status_sea_dict[datetime_str] = can_reserve
+            else:
+                ticket_status_land_dict[datetime_str] = can_reserve
+        date_list = list(set(list(ticket_status_land_dict.keys()) + list(ticket_status_sea_dict.keys())))
+        date_list.sort()
+        for date in date_list:
+            ticket_info = TicketReservationInfo()
+            ticket_info.date_str = date
+            ticket_info.last_update_str = last_update_time_dict[date]
+            if date in ticket_status_sea_dict:
+                ticket_info.one_day_pass_sea = ticket_status_sea_dict[date]
+            if date in ticket_status_land_dict:
+                ticket_info.one_day_pass_land = ticket_status_land_dict[date]
+            ticket_status_list.append(ticket_info)
+        return [ticket_status.to_dict() for ticket_status in ticket_status_list]
+

--- a/backend/disneyapp/urls.py
+++ b/backend/disneyapp/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('spot/list', views.spot_list, name="spot_list"),
     path('search', views.search, name="search"),
     path('business-hours', views.business_hours, name="business_hours"),
+    path('ticket-reservation', views.ticket_reservation, name="ticket_reservation"),
     path('debug', views.debug, name="debug"),
 ]

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -2,7 +2,7 @@ from disneyapp.data.spot_list_data_converter import SpotListDataConverter, Dynam
 from disneyapp.algorithm.models import TravelInput
 from disneyapp.algorithm.tsp_solver import RandomTspSolver
 from disneyapp.data.park_data_accessor import ParkDataAccessor
-from disneyapp.data.db_handler import DBHandler
+from disneyapp.data.ticket_reservation_accesor import TicketReservationAccessor
 
 import copy, json
 from rest_framework.response import Response
@@ -47,8 +47,7 @@ def business_hours(request):
 
 @api_view(['GET'])
 def ticket_reservation(request):
-    db_handler = DBHandler()
-    result = db_handler.fetch_ticket_reservation_info(from_time="2022-1-10", upto_time="2022-2-10")
+    result = TicketReservationAccessor.fetch_ticket_status_list()
     return Response(result)
 
 

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -44,6 +44,11 @@ def business_hours(request):
     )
 
 
+@api_view(['GET'])
+def ticket_reservation(request):
+    return Response("ticket reservation")
+
+
 @api_view(["GET"])
 def debug(request):
     return Response("Debug")

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -2,6 +2,7 @@ from disneyapp.data.spot_list_data_converter import SpotListDataConverter, Dynam
 from disneyapp.algorithm.models import TravelInput
 from disneyapp.algorithm.tsp_solver import RandomTspSolver
 from disneyapp.data.park_data_accessor import ParkDataAccessor
+from disneyapp.data.db_handler import DBHandler
 
 import copy, json
 from rest_framework.response import Response
@@ -46,7 +47,9 @@ def business_hours(request):
 
 @api_view(['GET'])
 def ticket_reservation(request):
-    return Response("ticket reservation")
+    db_handler = DBHandler()
+    result = db_handler.fetch_ticket_reservation_info(from_time="2022-1-10", upto_time="2022-2-10")
+    return Response(result)
 
 
 @api_view(["GET"])


### PR DESCRIPTION
### 概要
* チケット予約状況ページのためのAPIを追加
  * 未来30日分のチケット予約状況と、該当日付の天気予報を返したい
  * このプルリクではチケット予約状況のみ対応
    * 天気予報は別途実装
* 仕様をAPI仕様書に記載済
  * https://github.com/Nakajima2nd/disney-app/wiki/チケット予約情報取得API

### 検証
`http://localhost:8001/ticket-reservation` にアクセスして期待通りの結果になっていることを確認。
<img width="308" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/147802721-7779ccac-a845-456d-b2a8-31dd867b76fb.PNG">