### PR TITLE
PC用経路表示ボタンを追加他

### DIFF
--- a/frontend/components/Header.jsx
+++ b/frontend/components/Header.jsx
@@ -6,6 +6,9 @@ import { useRouter } from 'next/router'
 
 const CustomAppBar = styled(AppBar)`
   text-align: center;
+  max-width: 900px;
+  left: 50%;
+  transform: translate(-50%, 0);
 `
 
 const CustomToolbar = styled(Toolbar)`
@@ -26,6 +29,7 @@ const Dummy = styled.div`
   top: 0;
   left: 0;
   width: 100%;
+  max-width: 900px;
   height: 56px;
   background: linear-gradient(rgba(237, 249, 255, 0), rgba(255, 255, 255, 0.8));
 `

--- a/frontend/components/SpotSelect.jsx
+++ b/frontend/components/SpotSelect.jsx
@@ -3,6 +3,7 @@ import { Box, Tabs, Tab, TextField, InputAdornment } from '@material-ui/core'
 import { Restaurant, SportsTennis, AccessibilityNew, ShoppingCart, Search, Mood, Flag } from '@material-ui/icons'
 import { SpotList } from './SpotList'
 import { TabPanel } from '../styles/parts'
+import SwipeableViews from 'react-swipeable-views/lib/SwipeableViews'
 
 const KeywordInput = styled(TextField)`
   padding: 0 16px;
@@ -18,7 +19,21 @@ const SpotTab = styled(Tab)`
 const TabPanels = styled(Box)`
 `
 
+// やっつけ仕事
+const tabs = [
+  'attraction',
+  'restaurant',
+  'shop',
+  'place',
+  'show',
+  'greeting'
+]
+
 export const SpotSelect = ({ handleKeyword, handleTab, spotList, editing, handleClickSpot, checked, handleCheckbox, selected }) => {
+  const handleChangeIndex = index => {
+    handleTab(null, tabs[index])
+  }
+
   return (<>
     <KeywordInput
       value={editing.keyword}
@@ -48,22 +63,29 @@ export const SpotSelect = ({ handleKeyword, handleTab, spotList, editing, handle
       <SpotTab icon={<Mood />} label="グリーティング" value="greeting" />
     </SpotTabs>
     <TabPanels>
-      {Object.entries(spotList).map(([key, value], index) => (
-        <TabPanel
-          key={index}
-          value={editing.tab}
-          index={key}
-        >
-          <SpotList
-            list={value}
-            editing={editing}
-            handleClickSpot={handleClickSpot}
-            checked={checked}
-            handleCheckbox={handleCheckbox}
-            selected={selected}
-          />
-        </TabPanel>
-      ))}
+      <SwipeableViews
+        enableMouseEvents
+        index={tabs.findIndex(tab => tab === editing.tab)}
+        resistance
+        onChangeIndex={index => handleChangeIndex(index)}
+      >
+        {Object.entries(spotList).map(([key, value], index) => (
+          <TabPanel
+            key={index}
+            value={editing.tab}
+            index={key}
+          >
+            <SpotList
+              list={value}
+              editing={editing}
+              handleClickSpot={handleClickSpot}
+              checked={checked}
+              handleCheckbox={handleCheckbox}
+              selected={selected}
+            />
+          </TabPanel>
+        ))}
+      </SwipeableViews>
     </TabPanels>
   </>)
 }

--- a/frontend/hooks.js
+++ b/frontend/hooks.js
@@ -61,3 +61,18 @@ export const useGetSearchResult = (query) => {
     error: error
   }
 }
+
+export const useGetDevice = () => {
+  const [device, setDevice] = useState()
+  useEffect(() => {
+    const ua = navigator.userAgent.toLowerCase()
+    if (ua.indexOf('iphone') > -1 || ua.indexOf('ipad') > -1 || ua.indexOf('android') > -1) {
+      setDevice('sp')
+    }
+    else {
+      setDevice('pc')
+    }
+  }, [])
+
+  return device
+}

--- a/frontend/pages/search/index.js
+++ b/frontend/pages/search/index.js
@@ -3,7 +3,7 @@ import { Avatar, Box, Button, Card, MobileStepper, SwipeableDrawer, Typography }
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { Loading } from '../../components/Loading'
-import { useGetSearchResult } from '../../hooks'
+import { useGetDevice, useGetSearchResult } from '../../hooks'
 import { ArrowRightAlt, DirectionsWalk, Room, KeyboardArrowRight, KeyboardArrowLeft } from '@material-ui/icons'
 import { hasWaitTime } from '../../utils'
 import Head from 'next/head'
@@ -104,6 +104,15 @@ const Text = styled(Typography)`
 
 const ErrorText = styled(Typography)`
   margin: 16px 0 0 0;
+`
+
+const OpenButton = styled(Button)`
+  position: fixed;
+  bottom: 80px;
+  left: 8px;
+  background-color: rgba(255, 255, 255, 1);
+  font-size: 0.9rem;
+  font-weight: bold;
 `
 
 const Puller = styled(Box)`
@@ -229,6 +238,7 @@ const BackButton = styled(Button)`
 `
 
 const Search = ({ query }) => {
+  const device = useGetDevice()
   const router = useRouter()
   const { searchResult, error } = useGetSearchResult(query)
   const [open, setOpen] = useState(false)
@@ -260,6 +270,10 @@ const Search = ({ query }) => {
 
   const toggleDrawer = (newOpen) => () => {
     setOpen(newOpen)
+  }
+
+  const onClickOpen = () => {
+    setOpen(true)
   }
 
   const handleNextArrow = () => {
@@ -324,6 +338,15 @@ const Search = ({ query }) => {
         <CustomMap searchResult={searchResult} current={activeStep} />
       </MapWrap>
       <GlobalStyle />
+      {device === 'pc' &&
+        <OpenButton
+          onClick={onClickOpen}
+          variant="outlined"
+          color="secondary"
+        >
+          経路情報を表示
+        </OpenButton>
+      }
       <SwipeableDrawer
         anchor="bottom"
         open={open}


### PR DESCRIPTION
#### 修正点
* PCで表示した場合だけ、探索結果画面左下に経路表示ボタンを追加
* スポット選択画面のタブ切り替え(スポットタイプ切り替え)をスワイプでできるように修正
* 大きい画面で見た時、ヘッダーが画面いっぱいにならないように最大値を設定

<img width="1512" alt="スクリーンショット 2022-01-09 18 06 09" src="https://user-images.githubusercontent.com/55273685/148676152-66d7a168-845d-418d-8159-802cf7bc4fd3.png">
