### PR TITLE
DBから取得するチケット情報の上限日付を引き上げ

### DIFF
--- a/backend/disneyapp/data/ticket_reservation_accesor.py
+++ b/backend/disneyapp/data/ticket_reservation_accesor.py
@@ -8,7 +8,7 @@ class TicketReservationAccessor:
     @staticmethod
     def fetch_ticket_status_list():
         """
-        現在時刻から1か月分のチケット販売情報およい付随情報を返す。
+        現在時刻から2か月分のチケット販売情報およい付随情報を返す。
         """
         ticket_status_list = []
         num_of_target_date = 60 # 何日分の情報を返すか

--- a/backend/disneyapp/data/ticket_reservation_accesor.py
+++ b/backend/disneyapp/data/ticket_reservation_accesor.py
@@ -11,7 +11,7 @@ class TicketReservationAccessor:
         現在時刻から1か月分のチケット販売情報およい付随情報を返す。
         """
         ticket_status_list = []
-        num_of_target_date = 30 # 何日分の情報を返すか
+        num_of_target_date = 60 # 何日分の情報を返すか
         db_handler = DBHandler()
         dt_now = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=9)))
         dt_upto_time = dt_now + datetime.timedelta(days=num_of_target_date)


### PR DESCRIPTION
### 概要
* 現状、`/ticket-reservation` ではDBから「当日から1か月後」までのチケット空き情報を取得して返却している
* しかし実際にはディズニーのWebサイトでは2か月後までのチケットを予約できる
  * 参考：https://www.tokyodisneyresort.jp/ticket/index.html
* そのため、現実に合わせる形で2か月後までのチケット予約情報を返却するように改修した
  * API仕様書に反映済
  * 軽微な修正のためバックエンドをすでに本番反映済

### 検証
意図通り2か月後までの情報を返却していることを確認。
<img width="775" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/154856671-bde11441-aa02-470a-b1f5-ada0de2b1bdd.PNG">

