### PR TITLE
広告を /ticket のみに表示する

### DIFF
--- a/frontend/components/googleadsense.jsx
+++ b/frontend/components/googleadsense.jsx
@@ -1,7 +1,0 @@
-import Script from 'next/script'
-
-const GoogleAdsense = () => (
-    <Script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4896306900328304" crossorigin="anonymous"></Script>
-)
-
-export default GoogleAdsense

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -13,7 +13,6 @@ import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import { Header } from '../components/Header'
 import { Box } from '@material-ui/core'
 import GoogleAnalytics from '../components/GoogleAnalytics'
-import GoogleAdsense from '../components/googleadsense'
 import { useRouter } from 'next/router';
 import { existsGaId, pageview } from '../components/gtag'
 
@@ -60,7 +59,6 @@ const MyApp = ({ Component, pageProps }) => {
             <RecoilRoot>
               <Header />
               <Wrap>
-                <GoogleAdsense />
                 <GoogleAnalytics />
                 <Component {...pageProps} />
               </Wrap>

--- a/frontend/pages/ticket/index.js
+++ b/frontend/pages/ticket/index.js
@@ -116,6 +116,7 @@ const Ticket = ({ query }) => {
   return (<>
     <Head>
       <title>チケット予約|TDS計画ツール|ディズニープラン</title>
+      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4896306900328304" crossorigin="anonymous"></script>
       <meta property="og:title" content="チケット予約|TDS計画ツール|ディズニープラン" />
       <meta property="og:description" content="ディズニーランド・シーを効率よくめぐる計画をたてるwebアプリです！リアルタイム待ち時間を考慮しています！" />
       <meta property="og:image" content="/og.png" />


### PR DESCRIPTION
### 概要
実装内容はタイトルのとおり。
意図については下記の投稿を参照のこと。
https://coins-dawn.slack.com/archives/C01UWS1LH4P/p1646572732643389

### 検証
検証環境（https://disney-app-kl9tkm3lv-nakajima2nd.vercel.app）にて下記を確認済
* /ticket にアクセスした場合に、`https://pagead2.googlesyndication.com` にリクエストしていることを開発者コンソールから確認
* /about, /search にアクセスした場合に上記にアクセスしていないことを同様に確認