### PR TITLE
レストランの予約情報を取得するAPIを追加

### DIFF
--- a/backend/disneyapp/data/db_handler.py
+++ b/backend/disneyapp/data/db_handler.py
@@ -41,6 +41,30 @@ class DBHandler:
                 result = cur.fetchall()
                 return result
 
+    def fetch_restaurant_reservation_info(self):
+        """
+        レストラン予約情報をDBから取得する。
+        """
+        table_name = "drestaurant_status"
+        with psycopg2.connect(self.database_url, sslmode='require') as conn:
+            with conn.cursor(cursor_factory=DictCursor) as cur:
+                cur.execute(f"SELECT * FROM {table_name} ORDER BY target_date")
+                result = cur.fetchall()
+                return result
+
+    def fetch_restaurant_name_type_dict(self):
+        """
+        レストラン名称->typeの辞書を返却する。
+        """
+        table_name = "drestaurant_list"
+        name_type_dict = {}
+        with psycopg2.connect(self.database_url, sslmode='require') as conn:
+            with conn.cursor(cursor_factory=DictCursor) as cur:
+                cur.execute(f"SELECT * FROM {table_name}")
+                for row in cur:
+                    name_type_dict[row["restaurant_name"]] = row["type"]
+        return name_type_dict
+
     def fetch_all_weather_info(self):
         """
         すべての天気情報をDBから取得する。

--- a/backend/disneyapp/data/models.py
+++ b/backend/disneyapp/data/models.py
@@ -422,3 +422,22 @@ class TicketReservationInfo:
             },
             "weather" : self.weather_info.to_dict()
         }
+
+
+class RestaurantReservationInfo:
+    """
+    レストラン予約情報クラス。
+    """
+    def __init__(self, date_str, type_str, name, status):
+        self.date_str = date_str
+        self.type_str = type_str
+        self.name = name
+        self.status = status
+
+    def to_dict(self):
+        return {
+            "date-str": self.date_str,
+            "type-str": self.type_str,
+            "name": self.name,
+            "status": self.status
+        }

--- a/backend/disneyapp/data/restaurant_reservation_accessor.py
+++ b/backend/disneyapp/data/restaurant_reservation_accessor.py
@@ -23,7 +23,7 @@ class RestaurantReservationAccessor:
         return target_date_list
 
     @staticmethod
-    def fetch_restaurant_status_list():
+    def fetch_restaurant_status_list(type_str: str):
         """
         現在時刻から2か月分のレストランの空き状況を返す。
         """
@@ -52,6 +52,7 @@ class RestaurantReservationAccessor:
                                                               name=restaurant_name,
                                                               status=status)
                 restaurant_status_list.append(restaurant_status)
-        return [restaurant_status.to_dict() for restaurant_status in restaurant_status_list]
+        hotel_park_status_list = [restaurant_status.to_dict() for restaurant_status in restaurant_status_list]
+        return filter(lambda x:x["type-str"] == type_str, hotel_park_status_list)
 
 

--- a/backend/disneyapp/data/restaurant_reservation_accessor.py
+++ b/backend/disneyapp/data/restaurant_reservation_accessor.py
@@ -1,0 +1,57 @@
+from disneyapp.data.db_handler import DBHandler
+from disneyapp.data.models import RestaurantReservationInfo
+from datetime import datetime, timezone, timedelta
+from dateutil.relativedelta import relativedelta
+
+
+class RestaurantReservationAccessor:
+    @staticmethod
+    def get_target_date_list():
+        """
+        2か月分の日付オブジェクトを返す。
+        """
+        current_date = datetime.now(timezone(timedelta(hours=9)))
+        end_date = current_date + relativedelta(months=2) - timedelta(days=2)
+        target_date_list = [current_date]
+        should_continue = True
+        while should_continue:
+            next_date = current_date + timedelta(days=1)
+            current_date = next_date
+            target_date_list.append(next_date)
+            if next_date > end_date:
+                should_continue = False
+        return target_date_list
+
+    @staticmethod
+    def fetch_restaurant_status_list():
+        """
+        現在時刻から2か月分のレストランの空き状況を返す。
+        """
+        # DBからレストラン予約情報を取得する
+        db_handler = DBHandler()
+        db_result_list = db_handler.fetch_restaurant_reservation_info()
+        db_result_dict = {} # datetime, name -> can_reserve
+        for db_result in db_result_list:
+            datetime_str = str(db_result[0])
+            name = db_result[1]
+            can_reserve = db_result[2]
+            db_result_dict[(datetime_str, name)] = can_reserve
+
+        # 2か月分のdatetimeについてループをまわして、結果のリストを作成する
+        restaurant_status_list = []
+        name_type_dict = db_handler.fetch_restaurant_name_type_dict()
+        target_date_list = RestaurantReservationAccessor.get_target_date_list()
+        for target_date in target_date_list:
+            for restaurant_name, type in name_type_dict.items():
+                target_date_str = target_date.strftime('%Y-%m-%d')
+                status = db_result_dict.get((target_date_str, restaurant_name))
+                if not status:
+                    status = False
+                restaurant_status = RestaurantReservationInfo(date_str=target_date_str,
+                                                              type_str=type,
+                                                              name=restaurant_name,
+                                                              status=status)
+                restaurant_status_list.append(restaurant_status)
+        return [restaurant_status.to_dict() for restaurant_status in restaurant_status_list]
+
+

--- a/backend/disneyapp/data/restaurant_reservation_accessor.py
+++ b/backend/disneyapp/data/restaurant_reservation_accessor.py
@@ -23,7 +23,7 @@ class RestaurantReservationAccessor:
         return target_date_list
 
     @staticmethod
-    def fetch_restaurant_status_list(type_str: str):
+    def fetch_restaurant_status_list(type_str: str, key: str):
         """
         現在時刻から2か月分のレストランの空き状況を返す。
         """
@@ -53,6 +53,26 @@ class RestaurantReservationAccessor:
                                                               status=status)
                 restaurant_status_list.append(restaurant_status)
         hotel_park_status_list = [restaurant_status.to_dict() for restaurant_status in restaurant_status_list]
-        return filter(lambda x:x["type-str"] == type_str, hotel_park_status_list)
+        default_retval = filter(lambda x:x["type-str"] == type_str, hotel_park_status_list)
+        if key == "date":
+            # date-str がキーの辞書にして返す
+            ret_dict = {}
+            for data in default_retval:
+                if data["date-str"] not in ret_dict:
+                    ret_dict[data["date-str"]] = [data]
+                else:
+                    ret_dict[data["date-str"]].append(data)
+            return ret_dict
+        elif key == "restaurant":
+            # レストラン名称がキーの辞書にして返す
+            ret_dict = {}
+            for data in default_retval:
+                if data["name"] not in ret_dict:
+                    ret_dict[data["name"]] = [data]
+                else:
+                    ret_dict[data["name"]].append(data)
+            return ret_dict
+        else:
+            return default_retval
 
 

--- a/backend/disneyapp/data/ticket_reservation_accesor.py
+++ b/backend/disneyapp/data/ticket_reservation_accesor.py
@@ -8,7 +8,7 @@ class TicketReservationAccessor:
     @staticmethod
     def fetch_ticket_status_list():
         """
-        現在時刻から2か月分のチケット販売情報およい付随情報を返す。
+        現在時刻から2か月分のチケット販売情報および付随情報を返す。
         """
         ticket_status_list = []
         num_of_target_date = 60 # 何日分の情報を返すか

--- a/backend/disneyapp/urls.py
+++ b/backend/disneyapp/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('search', views.search, name="search"),
     path('business-hours', views.business_hours, name="business_hours"),
     path('ticket-reservation', views.ticket_reservation, name="ticket_reservation"),
-    path('restaurant-reservation', views.restaurant_reservation, name="restaurant_reservation"),
+    path('hotel-restaurant-reservation', views.hotel_restaurant_reservation, name="restaurant_reservation"),
+    path('park-restaurant-reservation', views.park_restaurant_reservation, name="restaurant_reservation"),
     path('debug', views.debug, name="debug"),
 ]

--- a/backend/disneyapp/urls.py
+++ b/backend/disneyapp/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path('search', views.search, name="search"),
     path('business-hours', views.business_hours, name="business_hours"),
     path('ticket-reservation', views.ticket_reservation, name="ticket_reservation"),
+    path('restaurant-reservation', views.restaurant_reservation, name="restaurant_reservation"),
     path('debug', views.debug, name="debug"),
 ]

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -51,9 +51,16 @@ def ticket_reservation(request):
     result = TicketReservationAccessor.fetch_ticket_status_list()
     return Response(result)
 
+
 @api_view(['GET'])
-def restaurant_reservation(request):
-    result = RestaurantReservationAccessor.fetch_restaurant_status_list()
+def hotel_restaurant_reservation(request):
+    result = RestaurantReservationAccessor.fetch_restaurant_status_list(type_str="hotel")
+    return Response(result)
+
+
+@api_view(['GET'])
+def park_restaurant_reservation(request):
+    result = RestaurantReservationAccessor.fetch_restaurant_status_list(type_str="park")
     return Response(result)
 
 

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -54,13 +54,19 @@ def ticket_reservation(request):
 
 @api_view(['GET'])
 def hotel_restaurant_reservation(request):
-    result = RestaurantReservationAccessor.fetch_restaurant_status_list(type_str="hotel")
+    key = None
+    if "key" in request.GET:
+        key = request.GET.get("key")
+    result = RestaurantReservationAccessor.fetch_restaurant_status_list(type_str="hotel", key=key)
     return Response(result)
 
 
 @api_view(['GET'])
 def park_restaurant_reservation(request):
-    result = RestaurantReservationAccessor.fetch_restaurant_status_list(type_str="park")
+    key = None
+    if "key" in request.GET:
+        key = request.GET.get("key")
+    result = RestaurantReservationAccessor.fetch_restaurant_status_list(type_str="park", key=key)
     return Response(result)
 
 

--- a/backend/disneyapp/views.py
+++ b/backend/disneyapp/views.py
@@ -3,7 +3,7 @@ from disneyapp.algorithm.models import TravelInput
 from disneyapp.algorithm.tsp_solver import RandomTspSolver
 from disneyapp.data.park_data_accessor import ParkDataAccessor
 from disneyapp.data.ticket_reservation_accesor import TicketReservationAccessor
-from disneyapp.data.weather_accessor import WeatherAccessor
+from disneyapp.data.restaurant_reservation_accessor import RestaurantReservationAccessor
 
 import copy, json
 from rest_framework.response import Response
@@ -49,6 +49,11 @@ def business_hours(request):
 @api_view(['GET'])
 def ticket_reservation(request):
     result = TicketReservationAccessor.fetch_ticket_status_list()
+    return Response(result)
+
+@api_view(['GET'])
+def restaurant_reservation(request):
+    result = RestaurantReservationAccessor.fetch_restaurant_status_list()
     return Response(result)
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ psycopg2-binary
 python-dotenv
 pytest
 requests
+python-dateutil


### PR DESCRIPTION
### 概要
* レストランの予約情報を取得するAPIを追加した
* `/restaurant-reservation` 
* 仕様書に記載済：https://github.com/Nakajima2nd/disney-app/wiki/レストラン空き状況API
  * 現状、日付×レストランのマトリクスの情報をひとつのリストとして返却している
  * フロントエンドの実装都合で、辞書で返却してほしい等あれば応じるので都度指摘くれ（今回じゃなくてもOK）

### 検証
`http://localhost:8001/restaurant-reservation` で期待通りの結果が返ってくることを確認。
<img width="375" alt="キャプチャ" src="https://user-images.githubusercontent.com/33785163/158064079-2212c8ae-1e70-4972-b5a7-2913c96e2729.PNG">

